### PR TITLE
Add mass editing

### DIFF
--- a/doc/epics/20250825_Mass_Edits.md
+++ b/doc/epics/20250825_Mass_Edits.md
@@ -24,13 +24,14 @@ The objectives are as follows:
     * If the user hits "yes" this should be the same as hitting "Save". If that save fails do not exit the application and follow the save failure workflow above.
 
 * Users should be able to select multiple files and edit tags en masse. 
-  * This should be able to occur both in the file pane of MainWindow, or in PropertiesWindow: 
-    * For MainWindow, the selected files should remain highlighted after the edit-in-place textbox appears and continue to be highlighted after editing is complete. The workflow for this should be otherwise identical to single-file edit-in-place, which each column edited highlighted if Autosave is disabled. 
-    * For PropertiesWindow, there are two possibilities, based on whether values for a given tag differ between all files:
-      * If they differ, text boxes should display "<< multiple values >>" slightly grayed-out. 
-        * If the user wants to edit that tag in all files and clicks the textbox, then the textbox becomes blank and wait for input, then stage that change for all selected files; 
-      * If they are all the same, it should display that value for editing.
-        * Behavior here should have the same workflow as editing a single file.
+  * This should be able to be performed from both the file pane of MainWindow, or in PropertiesWindow: 
+    * In PropertiesWindow, there are two possibilities, based on whether values for a given tag differ between all files:
+      * If tags differ between files for a given field, text boxes should display "<< multiple values >>" slightly grayed-out. 
+        * If the user wants to edit that tag in all files and clicks the textbox, then the textbox becomes blank and accepts input, then stages that change on all selected files; 
+      * If tags are all the same for a given field, it should display that value for editing.
+        * Behavior here should feel identical to editing a single file.
+    * In MainWindow, if multiple files are selected, the user can open PropertiesWindow either through the usual menu actions, *OR* double-clicking on the File pane in MainWindow. Note that this replaces the 'edit-in-place' functionality in that cirumstance.
+    
 
 * Build the foundations for a new feature called "analyzers": 
   * which are specialized modules that read the media file's data stream and produce some sort of metadata output. 

--- a/src/models/edit_manager.py
+++ b/src/models/edit_manager.py
@@ -10,10 +10,34 @@ from util.logging import log
 
 class EditManager(QObject):
     """
-    A singleton class to manage metadata edits across the application.
+    Manages operations related to staging, committing, and managing changes for media files.
 
-    Handles the distinction between generic tags (user-facing) and internal tags (provider-specific),
-    ensuring proper mapping and provider context for all metadata operations.
+    This class is a singleton. Passing instantiated objects to other classes will always return the same instance.
+
+    Provides functionality to stage changes, manage autosave, and perform both synchronous and asynchronous
+    commits for changes. This class ensures thread safety for operations and emits signals to notify about
+    important events such as change staging, commit progress, and completions.
+
+    Signals:
+        - staged_changes_exist: Indicates if there are staged changes, parameter is a boolean.
+        - autosave_changed: Indicates a change in autosave state, parameter is a boolean.
+        - commit_started: Emitted when a commit process starts.
+        - commit_progress: Emitted during the commit process. Parameters are current progress and total progress.
+        - commit_finished: Emitted upon successful commit, parameter is a list of file IDs.
+        - commit_failed: Emitted upon failed commit, parameter is a list of errors.
+
+    :ivar staged_changes_exist: Signal emitted when staged changes exist or no longer exist.
+    :type staged_changes_exist: Signal
+    :ivar autosave_changed: Signal emitted when autosave state changes.
+    :type autosave_changed: Signal
+    :ivar commit_started: Signal emitted when a commit is initiated.
+    :type commit_started: Signal
+    :ivar commit_progress: Signal emitted to report progress during the commit process.
+    :type commit_progress: Signal
+    :ivar commit_finished: Signal emitted upon successful commit completion, includes list of saved file IDs.
+    :type commit_finished: Signal
+    :ivar commit_failed: Signal emitted upon commit failure, includes list of errors.
+    :type commit_failed: Signal
     """
     staged_changes_exist = Signal(bool)
     autosave_changed = Signal(bool)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -10,18 +10,17 @@ from PySide6.QtCore import QDir, QThreadPool, Qt, QSortFilterProxyModel, QThread
 import windows
 from models.media_file import MediaFile
 from models.qt.metadata_model import MetadataTableModel
-from util.logging import log
 from workers.gui.load_files_worker import LoadFilesWorker
 from models.settings import settings, FileListSettings, ColumnSettings
 from models.edit_manager import EditManager
 from delegates.editable_metadata_delegate import EditableMetadataDelegate
 from util.const import KEY_IS_MEDIA, KEY_FILE_PATH
+from util.logging import log # Added import
 
 
 class MainWindow(QMainWindow):
     def __init__(self, path=None):
         super().__init__()
-        self.properties_window = None
         self.setWindowTitle("YAAMT")
         self.resize(1024, 768)
         self.setMinimumSize(640, 480)
@@ -322,14 +321,12 @@ class MainWindow(QMainWindow):
         about_window = windows.AboutWindow(self)
         about_window.exec()
 
-    def open_properties_window(self, selected_rows_data=None):
-        log.debug(f"open_properties_window: {selected_rows_data}")
-        if selected_rows_data is None:
-            selected_indexes = self.files_view.selectionModel().selectedRows()
-        else:
-            selected_indexes = selected_rows_data
+    def open_properties_window(self):
+        selected_indexes = self.files_view.selectionModel().selectedRows()
+        log.debug(f"selectedIndexes from selectionModel: {selected_indexes} (type: {type(selected_indexes)})")
 
         if not selected_indexes:
+            log.debug("No selected indexes, returning.")
             return
 
         media_files = []
@@ -345,9 +342,15 @@ class MainWindow(QMainWindow):
             self.properties_window.show()
 
     def on_files_view_double_clicked(self, index):
+        log.debug(f"on_files_view_double_clicked called with index: {index}")
         selected_indexes = self.files_view.selectionModel().selectedRows()
+        log.debug(f"Double-click: selected_indexes from selectionModel: {selected_indexes} (type: {type(selected_indexes)})")
         if len(selected_indexes) > 1:
-            self.open_properties_window(selected_indexes)
+            # this may not ever get called because the UI doesnt let you double-click multiple selected files
+            log.debug("Multiple files selected, calling open_properties_window.")
+            self.open_properties_window()
+        else:
+            log.debug("Single or no file selected by double-click, PropertiesWindow will not be opened by this handler.")
         # If a single row is selected, the default in-place editing will occur.
 
     def on_column_resized(self, logical_index, old_size, new_size):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QDir, QThreadPool, Qt, QSortFilterProxyModel, QThread
 import windows
 from models.media_file import MediaFile
 from models.qt.metadata_model import MetadataTableModel
+from util.logging import log
 from workers.gui.load_files_worker import LoadFilesWorker
 from models.settings import settings, FileListSettings, ColumnSettings
 from models.edit_manager import EditManager
@@ -20,6 +21,7 @@ from util.const import KEY_IS_MEDIA, KEY_FILE_PATH
 class MainWindow(QMainWindow):
     def __init__(self, path=None):
         super().__init__()
+        self.properties_window = None
         self.setWindowTitle("YAAMT")
         self.resize(1024, 768)
         self.setMinimumSize(640, 480)
@@ -321,6 +323,7 @@ class MainWindow(QMainWindow):
         about_window.exec()
 
     def open_properties_window(self, selected_rows_data=None):
+        log.debug(f"open_properties_window: {selected_rows_data}")
         if selected_rows_data is None:
             selected_indexes = self.files_view.selectionModel().selectedRows()
         else:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2,7 +2,7 @@ import os
 from PySide6.QtWidgets import (
     QMainWindow, QToolBar, QStatusBar, QSplitter, QLabel, QProgressBar,
     QPushButton, QStyle, QTreeView, QFileSystemModel, QMenu, QMessageBox,
-    QLineEdit, QSizePolicy, QFileDialog
+    QLineEdit, QSizePolicy, QFileDialog, QAbstractItemView
 )
 from PySide6.QtGui import QAction
 from PySide6.QtCore import QDir, QThreadPool, Qt, QSortFilterProxyModel, QThread, Slot
@@ -103,10 +103,12 @@ class MainWindow(QMainWindow):
         self.editable_delegate = EditableMetadataDelegate()
         self.files_view.setItemDelegate(self.editable_delegate)
         self.files_view.setSortingEnabled(True)
+        self.files_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.files_view.header().setContextMenuPolicy(Qt.CustomContextMenu)
         self.files_view.header().customContextMenuRequested.connect(self.on_header_context_menu)
         self.files_view.setContextMenuPolicy(Qt.CustomContextMenu)
         self.files_view.customContextMenuRequested.connect(self.on_files_view_customContextMenuRequested)
+        self.files_view.doubleClicked.connect(self.on_files_view_double_clicked)
 
         splitter.addWidget(self.files_view)
         splitter.setStretchFactor(0, 0)
@@ -318,8 +320,12 @@ class MainWindow(QMainWindow):
         about_window = windows.AboutWindow(self)
         about_window.exec()
 
-    def open_properties_window(self):
-        selected_indexes = self.files_view.selectionModel().selectedRows()
+    def open_properties_window(self, selected_rows_data=None):
+        if selected_rows_data is None:
+            selected_indexes = self.files_view.selectionModel().selectedRows()
+        else:
+            selected_indexes = selected_rows_data
+
         if not selected_indexes:
             return
 
@@ -334,6 +340,12 @@ class MainWindow(QMainWindow):
         if media_files:
             self.properties_window = windows.PropertiesWindow(media_files, self.edit_manager, self)
             self.properties_window.show()
+
+    def on_files_view_double_clicked(self, index):
+        selected_indexes = self.files_view.selectionModel().selectedRows()
+        if len(selected_indexes) > 1:
+            self.open_properties_window(selected_indexes)
+        # If a single row is selected, the default in-place editing will occur.
 
     def on_column_resized(self, logical_index, old_size, new_size):
         # This is now handled by _save_column_settings, which reads the visual layout

--- a/src/windows/properties_tabs/main_tab.py
+++ b/src/windows/properties_tabs/main_tab.py
@@ -1,4 +1,5 @@
 from PySide6.QtWidgets import QWidget, QFormLayout, QLineEdit, QGroupBox
+from PySide6.QtCore import QEvent
 from models.edit_manager import EditManager
 from util.const import (
     KEY_TITLE, KEY_ARTIST, KEY_ALBUM, KEY_ALBUM_ARTIST, KEY_DATE, KEY_GENRE,
@@ -58,6 +59,20 @@ class MainTab(QWidget):
         
         layout.addRow(replaygain_group)
 
+        # Connect focus events for clearing placeholders
+        self.title_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.title_edit)
+        self.artist_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.artist_edit)
+        self.album_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.album_edit)
+        self.album_artist_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.album_artist_edit)
+        self.date_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.date_edit)
+        self.genre_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.genre_edit)
+        self.comment_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.comment_edit)
+        self.composer_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.composer_edit)
+        self.track_num_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.track_num_edit)
+        self.disc_num_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.disc_num_edit)
+        self.bpm_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.bpm_edit)
+        self.key_edit.focusInEvent = lambda event: self._clear_placeholder_on_focus(event, self.key_edit)
+
         self.refresh()
 
         # Connect signals
@@ -78,25 +93,43 @@ class MainTab(QWidget):
         self.edit_manager.stage_change(self.media_files, generic_tag_name, new_value)
 
     def _get_display_value(self, tag_name):
+        if not self.media_files:
+            return ""
+
+        # Check for staged changes first. If any file has a staged change, that takes precedence.
+        # For simplicity, we'll check the first file. A more complex scenario might involve
+        # checking if all staged changes are the same.
         staged_value = self.edit_manager.get_staged_value_for_file(self.media_files[0], tag_name)
         if staged_value is not None:
+            # If a value is staged for the first file, we assume it's representative for all in this context.
+            # The edit manager handles applying it to all.
             return staged_value
 
-        values = {mf.get_tag_simple(tag_name) for mf in self.media_files}
+        values = set()
+        for mf in self.media_files:
+            val = mf.get_tag_simple(tag_name)
+            values.add(val)
+
         if len(values) == 1:
-            return values.pop()
-        return "<< multiple values >>"
+            return values.pop() if values.pop() is not None else ""
+        return None # Indicates multiple values
+
+    def _clear_placeholder_on_focus(self, event, line_edit):
+        if line_edit.placeholderText() == "<< multiple values >>":
+            line_edit.setPlaceholderText("")
+            line_edit.setStyleSheet("")
+        QLineEdit.focusInEvent(line_edit, event)
 
     def _populate_field(self, line_edit, tag_name):
         value = self._get_display_value(tag_name)
-        if value == "<< multiple values >>":
-            line_edit.setText(value)
+        if value is None: # Multiple values
+            line_edit.setText("")
+            line_edit.setPlaceholderText("<< multiple values >>")
             line_edit.setStyleSheet("color: gray;")
-            line_edit.setPlaceholderText("Enter a new value for all files")
-        else:
-            line_edit.setText(str(value or ''))
-            line_edit.setStyleSheet("")
+        else: # Single value or empty
+            line_edit.setText(str(value))
             line_edit.setPlaceholderText("")
+            line_edit.setStyleSheet("")
 
     def refresh(self):
         self._populate_field(self.title_edit, KEY_TITLE)

--- a/src/windows/properties_tabs/main_tab.py
+++ b/src/windows/properties_tabs/main_tab.py
@@ -111,7 +111,9 @@ class MainTab(QWidget):
             values.add(val)
 
         if len(values) == 1:
-            return values.pop() if values.pop() is not None else ""
+            popped = values.pop()
+            return popped if popped is not None else ""
+
         return None # Indicates multiple values
 
     def _clear_placeholder_on_focus(self, event, line_edit):


### PR DESCRIPTION
### Description

This pull request introduces several improvements, particularly focused on interactions within the file pane and the associated functionality. Specifically:

- Added support for multi-file selection to enable batch actions.
- Improved mass-editing capabilities for selected files.
- Enhanced double-click action handling for cleaner user interactions.
- Refactored `open_properties_window` logic for simplified handling of selected rows, improved logging, and better value management.
- Logged selected rows data when opening the properties window for better debugging insights and initialized the `properties_window` attribute.
- Updated and clarified related documentation