### PR TITLE
Implement debug mode system with build-time and runtime controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,26 +45,17 @@ On Windows, use `.\.venv\Scripts\activate` instead of `source .venv/bin/activate
 
 ## Usage
 
-In all usecases, it is best to activate the virtual environment before running the application.
+Convenience scripts are provided in the repository root: `yaamt.sh` / `yaamt.bat` for the CLI and `yaamt-gui.sh` / `yaamt-gui.bat` for the GUI. These automatically use the virtual environment and are shorthand for running `python src/yaamt.py` and `python src/yaamt-gui.py` respectively.
 
-Linux/macOS:
-```bash
-cd yaamt
-source .venv/bin/activate
-```
-
-Windows:
-```powershell
-cd yaamt
-.venv\Scripts\activate
-```
+**Note:** On Linux/macOS, make the shell scripts executable first: `chmod +x yaamt.sh yaamt-gui.sh`
 
 ### GUI Mode
 
-To launch the graphical user interface, run:
+To launch the graphical user interface:
 
 ```bash
-python src/gui.py
+./yaamt-gui.sh      # Linux/macOS
+.\yaamt-gui.bat     # Windows
 ```
 
 ### Command-Line Usage
@@ -75,30 +66,30 @@ The command-line interface provides powerful options for scripting and batch pro
 
 **Top-level help:**
 ```bash
-python src/yaamt.py --help
+./yaamt.sh --help
 ```
 
 **Help for specific commands:**
 ```bash
-python src/yaamt.py help read
-python src/yaamt.py help write
-python src/yaamt.py help analyze
+./yaamt.sh help read
+./yaamt.sh help write
+./yaamt.sh help analyze
 ```
 
 **List available analyzers:**
 ```bash
-python src/yaamt.py list analyzers
+./yaamt.sh list analyzers
 ```
 
 **List analyzers by category:**
 ```bash
-python src/yaamt.py list analyzers --category bpm
-python src/yaamt.py list analyzers --category key
+./yaamt.sh list analyzers --category bpm
+./yaamt.sh list analyzers --category key
 ```
 
 **Get help on a specific analyzer:**
 ```bash
-python src/yaamt.py analyze StubBPMAnalyzer --help
+./yaamt.sh analyze StubBPMAnalyzer --help
 ```
 
 #### Reading Metadata
@@ -107,32 +98,32 @@ The `read` command displays metadata from audio files. It supports multiple outp
 
 **Display metadata for a single file (detailed list format):**
 ```bash
-python src/yaamt.py read "path/to/audio.mp3" -f list
+./yaamt.sh read "path/to/audio.mp3" -f list
 ```
 
 **Display metadata for multiple files (table format with separated directory/filename columns):**
 ```bash
-python src/yaamt.py read "path/to/folder/*.mp3" -f table
+./yaamt.sh read "path/to/folder/*.mp3" -f table
 ```
 
 **Show only specific tags:**
 ```bash
-python src/yaamt.py read "path/to/audio.mp3" --tags title,artist,album,bpm
+./yaamt.sh read "path/to/audio.mp3" --tags title,artist,album,bpm
 ```
 
 **Export metadata from a folder to CSV:**
 ```bash
-python src/yaamt.py read "path/to/folder/*.mp3" -f csv -o metadata.csv
+./yaamt.sh read "path/to/folder/*.mp3" -f csv -o metadata.csv
 ```
 
 **Export metadata to JSON:**
 ```bash
-python src/yaamt.py read "path/to/folder/*.mp3" -f json -o metadata.json
+./yaamt.sh read "path/to/folder/*.mp3" -f json -o metadata.json
 ```
 
 **Recursively scan subdirectories:**
 ```bash
-python src/yaamt.py read "path/to/folder" -R --tags title,artist,bpm -f table
+./yaamt.sh read "path/to/folder" -R --tags title,artist,bpm -f table
 ```
 
 #### Writing Metadata
@@ -141,12 +132,12 @@ The `write` command modifies metadata tags on audio files. You can use either th
 
 **Using shortcut parameters (recommended for common tags):**
 ```bash
-python src/yaamt.py write --title "New Song Title" --artist "Artist Name" "path/to/audio.mp3"
+./yaamt.sh write --title "New Song Title" --artist "Artist Name" "path/to/audio.mp3"
 ```
 
 **Using the generic --tag option:**
 ```bash
-python src/yaamt.py write --tag "title=New Song Title" --tag "artist=Artist Name" "path/to/audio.mp3"
+./yaamt.sh write --tag "title=New Song Title" --tag "artist=Artist Name" "path/to/audio.mp3"
 ```
 
 **Available shortcut parameters:**
@@ -159,12 +150,12 @@ python src/yaamt.py write --tag "title=New Song Title" --tag "artist=Artist Name
 
 **Mass-write album tag to all files in a folder (e.g., for an album):**
 ```bash
-python src/yaamt.py write --album "My Album Name" "path/to/album/*.mp3"
+./yaamt.sh write --album "My Album Name" "path/to/album/*.mp3"
 ```
 
 **Write multiple tags at once using shortcuts:**
 ```bash
-python src/yaamt.py write \
+./yaamt.sh write \
   --title "Song Title" \
   --artist "Artist Name" \
   --album "Album Name" \
@@ -174,7 +165,7 @@ python src/yaamt.py write \
 
 **Recursively update all files in a directory tree:**
 ```bash
-python src/yaamt.py write --albumartist "Various Artists" "path/to/folder" -R
+./yaamt.sh write --albumartist "Various Artists" "path/to/folder" -R
 ```
 
 #### Analyzing Files
@@ -183,27 +174,27 @@ The `analyze` command runs audio analysis algorithms to detect BPM, musical key,
 
 **Analyze a single file for BPM and write to file metadata:**
 ```bash
-python src/yaamt.py analyze StubBPMAnalyzer "path/to/audio.mp3" -w
+./yaamt.sh analyze StubBPMAnalyzer "path/to/audio.mp3" -w
 ```
 
 **Analyze a whole folder for musical key and output to CSV report:**
 ```bash
-python src/yaamt.py analyze WaveletKeyAnalyzer "path/to/folder/*.mp3" -f csv -o key_report.csv
+./yaamt.sh analyze WaveletKeyAnalyzer "path/to/folder/*.mp3" -f csv -o key_report.csv
 ```
 
 **Analyze files without writing to metadata (display results only):**
 ```bash
-python src/yaamt.py analyze MultibandSpectralBPMAnalyzer "path/to/audio.mp3" -f table
+./yaamt.sh analyze MultibandSpectralBPMAnalyzer "path/to/audio.mp3" -f table
 ```
 
 **Skip files that already have values (useful for partial processing):**
 ```bash
-python src/yaamt.py analyze StubBPMAnalyzer "path/to/folder/*.mp3" -w --skip-if-tag-exists
+./yaamt.sh analyze StubBPMAnalyzer "path/to/folder/*.mp3" -w --skip-if-tag-exists
 ```
 
 **Analyze with custom analyzer options:**
 ```bash
-python src/yaamt.py analyze AubioBPMAnalyzer "path/to/audio.mp3" -w --method default --buf-size 1024
+./yaamt.sh analyze AubioBPMAnalyzer "path/to/audio.mp3" -w --method default --buf-size 1024
 ```
 
 **Available Analyzers:**
@@ -215,8 +206,8 @@ python src/yaamt.py analyze AubioBPMAnalyzer "path/to/audio.mp3" -w --method def
 
 For a complete list of available analyzers and their options:
 ```bash
-python src/yaamt.py list analyzers
-python src/yaamt.py analyze <AnalyzerName> --help
+./yaamt.sh list analyzers
+./yaamt.sh analyze <AnalyzerName> --help
 ```
 
 ## Contributing

--- a/build.py
+++ b/build.py
@@ -441,13 +441,15 @@ class Builder:
 
     def _build_with_nuitka(self):
         """Build using Nuitka"""
-        dist_dir = self.config.get_nuitka_dist_dir()
-        dist_dir.mkdir(parents=True, exist_ok=True)
+        # Use relative path when building in temp workspace
+        # (we're already chdir'd to temp workspace at this point)
+        dist_dir_relative = self.config.output_dir.relative_to(self.config.project_root)
+        dist_dir_relative.mkdir(parents=True, exist_ok=True)
 
         if self.config.platform == "windows":
-            self._build_nuitka_windows(dist_dir)
+            self._build_nuitka_windows(dist_dir_relative)
         else:
-            self._build_nuitka_linux(dist_dir)
+            self._build_nuitka_linux(dist_dir_relative)
 
     def _build_nuitka_windows(self, dist_dir):
         """Build with Nuitka on Windows"""

--- a/build.py
+++ b/build.py
@@ -44,11 +44,16 @@ class BuildConfig:
         self.platform = platform_name or self._detect_platform()
         self.arch = arch or self._detect_arch()
         self.build_mode = build_mode  # 'debug' or 'release'
+        self.project_root = Path(__file__).parent.resolve()
+
         # Create build-mode-specific output directory with timestamp
         base_output_dir = Path(output_dir or "build")
+        # Make it absolute relative to project root if it's not already absolute
+        if not base_output_dir.is_absolute():
+            base_output_dir = self.project_root / base_output_dir
+
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         self.output_dir = base_output_dir / f"{build_mode}-{timestamp}"
-        self.project_root = Path(__file__).parent.resolve()
 
     def _detect_platform(self):
         """Detect the current platform"""

--- a/build.py
+++ b/build.py
@@ -22,6 +22,8 @@ import platform
 import subprocess
 import argparse
 import shutil
+import tempfile
+import re
 from pathlib import Path
 
 DEBIAN_LINUX_DEPS = ["ccache", "patchelf", "alien", "libegl1", "libxkbcommon-x11-0",
@@ -37,10 +39,13 @@ WINDOWS_CHOCO_DEPS = ["ccache"]
 class BuildConfig:
     """Configuration for building YAAMT"""
 
-    def __init__(self, platform_name=None, arch=None, output_dir=None):
+    def __init__(self, platform_name=None, arch=None, output_dir=None, build_mode='debug'):
         self.platform = platform_name or self._detect_platform()
         self.arch = arch or self._detect_arch()
-        self.output_dir = Path(output_dir or "build")
+        self.build_mode = build_mode  # 'debug' or 'release'
+        # Create build-mode-specific output directory
+        base_output_dir = Path(output_dir or "build")
+        self.output_dir = base_output_dir / build_mode
         self.project_root = Path(__file__).parent.resolve()
 
     def _detect_platform(self):
@@ -153,6 +158,126 @@ class DependencyInstaller:
         subprocess.run([sys.executable, "-m", "pip", "install"] + build_deps, check=True)
 
 
+# ============================================================================
+# Build Workspace Management
+# ============================================================================
+
+def create_build_workspace(build_mode: str, project_root: Path) -> Path:
+    """
+    Create a temporary build workspace by copying the source tree.
+
+    Args:
+        build_mode: 'debug' or 'release'
+        project_root: Path to the project root directory
+
+    Returns:
+        Path to the temporary workspace directory
+    """
+    # Create temp directory with descriptive prefix
+    temp_dir = tempfile.mkdtemp(prefix=f'yaamt_build_{build_mode}_')
+    temp_path = Path(temp_dir)
+
+    print(f"Creating build workspace at: {temp_path}")
+
+    # Patterns to ignore when copying
+    ignore_patterns = shutil.ignore_patterns(
+        '.git', '__pycache__', '*.pyc', '*.pyo',
+        'build', 'dist', '.pytest_cache', '.venv',
+        '*.egg-info', '.eggs', '.tox', 'venv'
+    )
+
+    # Copy source tree to temp directory
+    try:
+        shutil.copytree(project_root, temp_path / 'yaamt', ignore=ignore_patterns, dirs_exist_ok=True)
+        print(f"Source tree copied to workspace")
+        return temp_path / 'yaamt'
+    except Exception as e:
+        # Clean up temp dir if copy fails
+        shutil.rmtree(temp_path, ignore_errors=True)
+        raise RuntimeError(f"Failed to create build workspace: {e}")
+
+
+def prepare_source_for_build(temp_src_path: Path, build_mode: str) -> None:
+    """
+    Prepare the copied source for building by patching constants and
+    removing debug-only code for release builds.
+
+    Args:
+        temp_src_path: Path to the temporary source directory
+        build_mode: 'debug' or 'release'
+    """
+    print(f"Preparing source for {build_mode} build...")
+
+    const_file = temp_src_path / 'src' / 'util' / 'const.py'
+
+    # Read const.py
+    with open(const_file, 'r') as f:
+        content = f.read()
+
+    # Patch IS_DEBUG_BUILD constant
+    is_debug_value = 'True' if build_mode == 'debug' else 'False'
+    content = re.sub(
+        r'IS_DEBUG_BUILD\s*=\s*(True|False)',
+        f'IS_DEBUG_BUILD = {is_debug_value}',
+        content
+    )
+
+    # Get version string from git
+    try:
+        version_result = subprocess.run(
+            ['git', 'describe', '--tags', '--always', '--dirty'],
+            cwd=temp_src_path,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        version_string = version_result.stdout.strip()
+    except subprocess.CalledProcessError:
+        version_string = "unknown"
+
+    # Patch VERSION_STRING
+    content = re.sub(
+        r'VERSION_STRING\s*=\s*None',
+        f'VERSION_STRING = "{version_string}"',
+        content
+    )
+
+    # Write patched const.py
+    with open(const_file, 'w') as f:
+        f.write(content)
+
+    print(f"  Patched IS_DEBUG_BUILD = {is_debug_value}")
+    print(f"  Patched VERSION_STRING = {version_string}")
+
+    # For release builds, remove DEBUG_ONLY lines from _manifest.py
+    if build_mode == 'release':
+        manifest_file = temp_src_path / 'src' / 'providers' / 'analysis' / '_manifest.py'
+
+        with open(manifest_file, 'r') as f:
+            lines = f.readlines()
+
+        # Filter out lines with DEBUG_ONLY marker
+        filtered_lines = [line for line in lines if '# DEBUG_ONLY' not in line]
+
+        with open(manifest_file, 'w') as f:
+            f.writelines(filtered_lines)
+
+        removed_count = len(lines) - len(filtered_lines)
+        print(f"  Removed {removed_count} DEBUG_ONLY analyzer(s) from manifest")
+
+
+def cleanup_build_workspace(temp_path: Path) -> None:
+    """
+    Clean up the temporary build workspace.
+
+    Args:
+        temp_path: Path to the temporary workspace directory
+    """
+    if temp_path.exists():
+        print(f"Cleaning up build workspace: {temp_path}")
+        shutil.rmtree(temp_path, ignore_errors=True)
+
+
 class Builder:
     """Handles the actual build process"""
 
@@ -165,16 +290,46 @@ class Builder:
         ]
 
     def build(self):
-        """Execute the build process"""
+        """Execute the build process using temporary workspace"""
         build_tool = self.config.get_build_tool()
 
         print(f"\nBuilding YAAMT for {self.config.platform}-{self.config.arch}")
+        print(f"Build mode: {self.config.build_mode}")
         print(f"Using build tool: {build_tool}\n")
 
-        if build_tool == "nuitka":
-            self._build_with_nuitka()
-        else:
-            self._build_with_cx_freeze()
+        # Create temporary build workspace
+        temp_workspace = create_build_workspace(self.config.build_mode, self.config.project_root)
+
+        try:
+            # Prepare source for build (patch constants, remove debug-only code)
+            prepare_source_for_build(temp_workspace, self.config.build_mode)
+
+            # Save original working directory
+            original_cwd = os.getcwd()
+
+            try:
+                # Change to temp workspace for build
+                os.chdir(temp_workspace)
+
+                # Build from temp workspace
+                if build_tool == "nuitka":
+                    self._build_with_nuitka()
+                else:
+                    self._build_with_cx_freeze()
+
+            finally:
+                # Restore original working directory
+                os.chdir(original_cwd)
+
+            # Build succeeded - cleanup temp workspace
+            cleanup_build_workspace(temp_workspace)
+
+        except Exception as e:
+            # Build failed - preserve workspace for debugging
+            print(f"\n✗ Build failed: {e}")
+            print(f"\nTemp workspace preserved at: {temp_workspace}")
+            print(f"To clean up manually: rm -rf {temp_workspace}")
+            raise
 
     def _build_with_nuitka(self):
         """Build using Nuitka"""
@@ -319,6 +474,12 @@ def main():
     )
 
     parser.add_argument(
+        "--release",
+        action="store_true",
+        help="Build in release mode (default is debug mode)"
+    )
+
+    parser.add_argument(
         "--archive",
         action="store_true",
         help="Create archive of build artifacts"
@@ -348,17 +509,22 @@ def main():
     args = parser.parse_args()
 
     try:
+        # Determine build mode
+        build_mode = 'release' if args.release else 'debug'
+
         # Initialize configuration
         config = BuildConfig(
             platform_name=args.platform,
             arch=args.arch,
-            output_dir=args.output_dir
+            output_dir=args.output_dir,
+            build_mode=build_mode
         )
 
         print(f"YAAMT Build Script")
         print(f"==================")
         print(f"Platform: {config.platform}")
         print(f"Architecture: {config.arch}")
+        print(f"Build mode: {config.build_mode}")
         print(f"Build tool: {config.get_build_tool()}")
         print(f"Output directory: {config.output_dir}")
         print()

--- a/build.py
+++ b/build.py
@@ -25,6 +25,7 @@ import shutil
 import tempfile
 import re
 from pathlib import Path
+from datetime import datetime
 
 DEBIAN_LINUX_DEPS = ["ccache", "patchelf", "alien", "libegl1", "libxkbcommon-x11-0",
                      "libxcb-icccm4", "libxcb-image0", "libxcb-keysyms1", "libxcb-randr0",
@@ -43,9 +44,10 @@ class BuildConfig:
         self.platform = platform_name or self._detect_platform()
         self.arch = arch or self._detect_arch()
         self.build_mode = build_mode  # 'debug' or 'release'
-        # Create build-mode-specific output directory
+        # Create build-mode-specific output directory with timestamp
         base_output_dir = Path(output_dir or "build")
-        self.output_dir = base_output_dir / build_mode
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        self.output_dir = base_output_dir / f"{build_mode}-{timestamp}"
         self.project_root = Path(__file__).parent.resolve()
 
     def _detect_platform(self):
@@ -287,6 +289,65 @@ def cleanup_build_workspace(temp_path: Path) -> None:
         shutil.rmtree(temp_path, ignore_errors=True)
 
 
+def cleanup_build_directories(output_dir: str = "build") -> None:
+    """
+    Clean up all timestamped build directories.
+
+    Removes all directories matching the pattern:
+    - build/debug-YYYYMMDD-HHMMSS/
+    - build/release-YYYYMMDD-HHMMSS/
+
+    Args:
+        output_dir: Base output directory (default: "build")
+    """
+    build_path = Path(output_dir)
+
+    if not build_path.exists():
+        print(f"Build directory does not exist: {build_path}")
+        return
+
+    # Pattern to match timestamped build directories
+    # Format: debug-YYYYMMDD-HHMMSS or release-YYYYMMDD-HHMMSS
+    import glob
+
+    patterns = [
+        str(build_path / "debug-*"),
+        str(build_path / "release-*")
+    ]
+
+    directories_found = []
+    for pattern in patterns:
+        directories_found.extend(glob.glob(pattern))
+
+    if not directories_found:
+        print(f"No timestamped build directories found in {build_path}")
+        return
+
+    print(f"Found {len(directories_found)} build director{'y' if len(directories_found) == 1 else 'ies'} to clean:")
+    for directory in directories_found:
+        print(f"  - {directory}")
+
+    # Confirm deletion
+    confirm = input("\nDelete these directories? [y/N]: ").strip().lower()
+    if confirm != 'y':
+        print("Cleanup cancelled.")
+        return
+
+    # Delete directories
+    deleted = 0
+    failed = 0
+    for directory in directories_found:
+        try:
+            shutil.rmtree(directory)
+            print(f"  ✓ Deleted: {directory}")
+            deleted += 1
+        except Exception as e:
+            print(f"  ✗ Failed to delete {directory}: {e}")
+            failed += 1
+
+    print(f"\nCleanup complete: {deleted} deleted, {failed} failed")
+
+
 class Builder:
     """Handles the actual build process"""
 
@@ -516,6 +577,12 @@ def main():
     )
 
     parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clean up all timestamped build directories, then exit"
+    )
+
+    parser.add_argument(
         "--version-name",
         help="Version name for archive (default: local)"
     )
@@ -533,6 +600,11 @@ def main():
     args = parser.parse_args()
 
     try:
+        # Handle cleanup request (doesn't require config)
+        if args.clean:
+            cleanup_build_directories(args.output_dir)
+            return
+
         # Determine build mode
         build_mode = 'release' if args.release else 'debug'
 

--- a/build.py
+++ b/build.py
@@ -355,7 +355,7 @@ class Builder:
         self.config = config
         self.universal_nuitka_opts = [
             "--assume-yes-for-downloads",
-            "--onefile", #omitting this triggers antivirus
+            "--onefile",  # omitting this triggers antivirus
             "--standalone"
         ]
 
@@ -431,24 +431,29 @@ class Builder:
 
         universal_windows_opts = [
             "--mingw64",
-            "--clang", #do not remove this CLAUDE, it is not "unnecessary"
+            "--clang",  # do not remove this CLAUDE, it is not "unnecessary"
             # "--msvc=latest",
-            "--nofollow-import-to=cffi", #cffi crashes LLVM's 'vector-combine' optimization pass, per claude
+            "--nofollow-import-to=cffi,scipy",  # cffi crashes LLVM's 'vector-combine' optimization pass, per claude
             f"--output-dir={dist_dir}"
         ]
 
         print("=== Building CLI EXE with Nuitka (Windows)... ===")
-        cmd_opts = ["src/yaamt.py"]
+        cmd_opts = [
+            # other cmdline options would go here
+            "src/yaamt.py"
+        ]
 
-        cmd_args = [ sys.executable, "-m", "nuitka" ] + self.universal_nuitka_opts + universal_windows_opts + cmd_opts
+        cmd_args = [sys.executable, "-m", "nuitka"] + self.universal_nuitka_opts + universal_windows_opts + cmd_opts
         subprocess.run(cmd_args, check=True)
 
         print("=== Building GUI EXE with Nuitka (Windows)... ===")
-        gui_opts = ["--follow-imports",
-                    "--plugin-enable=pyside6",
-                    "--windows-console-mode=attach",
-                    "--include-module=cffi",
-                    "src/yaamt-gui.py" ]
+        gui_opts = [
+            "--follow-imports",
+            "--plugin-enable=pyside6",
+            "--windows-console-mode=attach",
+            # "--include-module=cffi",
+            "src/yaamt-gui.py"
+        ]
 
         gui_args = [sys.executable, "-m", "nuitka"] + self.universal_nuitka_opts + universal_windows_opts + gui_opts
         subprocess.run(gui_args, check=True)
@@ -460,7 +465,7 @@ class Builder:
         ]
 
         print("=== Building CLI with Nuitka (Linux)... ===")
-        cmd_args = ["nuitka" ] + self.universal_nuitka_opts + universal_linux_opts + ["src/yaamt.py"]
+        cmd_args = ["nuitka"] + self.universal_nuitka_opts + universal_linux_opts + ["src/yaamt.py"]
         subprocess.run(cmd_args, check=True)
 
         print("=== Building GUI with Nuitka (Linux)... ===")

--- a/build.py
+++ b/build.py
@@ -164,7 +164,12 @@ class DependencyInstaller:
 
 def create_build_workspace(build_mode: str, project_root: Path) -> Path:
     """
-    Create a temporary build workspace by copying the source tree.
+    Create a temporary build workspace by copying only the necessary files.
+
+    Only copies:
+    - src/ directory (source code)
+    - resources/ directory (for GUI assets)
+    - setup.py (for cx_Freeze builds)
 
     Args:
         build_mode: 'debug' or 'release'
@@ -179,25 +184,41 @@ def create_build_workspace(build_mode: str, project_root: Path) -> Path:
 
     print(f"Creating build workspace at: {temp_path}")
 
-    # Patterns to ignore when copying
-    ignore_patterns = shutil.ignore_patterns(
-        '.git', '__pycache__', '*.pyc', '*.pyo',
-        'build', 'dist', '.pytest_cache', '.venv',
-        '*.egg-info', '.eggs', '.tox', 'venv'
-    )
-
-    # Copy source tree to temp directory
+    # Copy only what's needed for builds
     try:
-        shutil.copytree(project_root, temp_path / 'yaamt', ignore=ignore_patterns, dirs_exist_ok=True)
-        print(f"Source tree copied to workspace")
-        return temp_path / 'yaamt'
+        workspace_root = temp_path / 'yaamt'
+        workspace_root.mkdir(parents=True, exist_ok=True)
+
+        # Copy src/ directory
+        src_dest = workspace_root / 'src'
+        shutil.copytree(
+            project_root / 'src',
+            src_dest,
+            ignore=shutil.ignore_patterns('__pycache__', '*.pyc', '*.pyo')
+        )
+        print(f"  Copied src/")
+
+        # Copy resources/ directory
+        resources_dest = workspace_root / 'resources'
+        if (project_root / 'resources').exists():
+            shutil.copytree(project_root / 'resources', resources_dest)
+            print(f"  Copied resources/")
+
+        # Copy setup.py (needed for cx_Freeze)
+        setup_src = project_root / 'setup.py'
+        if setup_src.exists():
+            shutil.copy2(setup_src, workspace_root / 'setup.py')
+            print(f"  Copied setup.py")
+
+        print(f"Build workspace created")
+        return workspace_root
     except Exception as e:
         # Clean up temp dir if copy fails
         shutil.rmtree(temp_path, ignore_errors=True)
         raise RuntimeError(f"Failed to create build workspace: {e}")
 
 
-def prepare_source_for_build(temp_src_path: Path, build_mode: str) -> None:
+def prepare_source_for_build(temp_src_path: Path, build_mode: str, version_string: str) -> None:
     """
     Prepare the copied source for building by patching constants and
     removing debug-only code for release builds.
@@ -205,6 +226,7 @@ def prepare_source_for_build(temp_src_path: Path, build_mode: str) -> None:
     Args:
         temp_src_path: Path to the temporary source directory
         build_mode: 'debug' or 'release'
+        version_string: Version string to embed in the build
     """
     print(f"Preparing source for {build_mode} build...")
 
@@ -221,19 +243,6 @@ def prepare_source_for_build(temp_src_path: Path, build_mode: str) -> None:
         f'IS_DEBUG_BUILD = {is_debug_value}',
         content
     )
-
-    # Get version string from git
-    try:
-        version_result = subprocess.run(
-            ['git', 'describe', '--tags', '--always', '--dirty'],
-            cwd=temp_src_path,
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        version_string = version_result.stdout.strip()
-    except subprocess.CalledProcessError:
-        version_string = "unknown"
 
     # Patch VERSION_STRING
     content = re.sub(
@@ -297,12 +306,27 @@ class Builder:
         print(f"Build mode: {self.config.build_mode}")
         print(f"Using build tool: {build_tool}\n")
 
+        # Get version string from git in original repo (before copying)
+        try:
+            version_result = subprocess.run(
+                ['git', 'describe', '--tags', '--always', '--dirty'],
+                cwd=self.config.project_root,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            version_string = version_result.stdout.strip()
+        except subprocess.CalledProcessError:
+            version_string = "unknown"
+
+        print(f"Version: {version_string}\n")
+
         # Create temporary build workspace
         temp_workspace = create_build_workspace(self.config.build_mode, self.config.project_root)
 
         try:
             # Prepare source for build (patch constants, remove debug-only code)
-            prepare_source_for_build(temp_workspace, self.config.build_mode)
+            prepare_source_for_build(temp_workspace, self.config.build_mode, version_string)
 
             # Save original working directory
             original_cwd = os.getcwd()

--- a/build.py
+++ b/build.py
@@ -396,7 +396,7 @@ class Builder:
                 # Change to temp workspace for build
                 os.chdir(temp_workspace)
 
-                # Build from temp workspace
+                # Build from temp workspace (artifacts go to temp_workspace/build/{mode}-{timestamp}/)
                 if build_tool == "nuitka":
                     self._build_with_nuitka()
                 else:
@@ -405,6 +405,24 @@ class Builder:
             finally:
                 # Restore original working directory
                 os.chdir(original_cwd)
+
+            # Copy build artifacts from temp workspace to project root
+            temp_build_dir = temp_workspace / self.config.output_dir.relative_to(self.config.project_root)
+            final_build_dir = self.config.output_dir
+
+            print(f"\nCopying build artifacts...")
+            print(f"  From: {temp_build_dir}")
+            print(f"  To:   {final_build_dir}")
+
+            if temp_build_dir.exists():
+                # Create parent directory if needed
+                final_build_dir.parent.mkdir(parents=True, exist_ok=True)
+
+                # Copy the entire build directory
+                shutil.copytree(temp_build_dir, final_build_dir, dirs_exist_ok=True)
+                print(f"  ✓ Build artifacts copied successfully")
+            else:
+                raise RuntimeError(f"Build artifacts not found at {temp_build_dir}")
 
             # Build succeeded - cleanup temp workspace
             cleanup_build_workspace(temp_workspace)

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,21 @@ def revert_const_file():
 # Get version from git
 version = get_version_from_git()
 
-# Patch the const.py file with the version
+# Check if const.py has already been patched by the build system
+const_file_path = os.path.join("src", "util", "const.py")
+with open(const_file_path, 'r') as f:
+    const_content = f.read()
+
+# Check if VERSION_STRING is already set (not None)
+already_patched = 'VERSION_STRING = None' not in const_content
+
+# Patch the const.py file with the version if not already patched
 try:
-    patch_const_file(version)
+    if not already_patched:
+        patch_const_file(version)
+        print("Patched VERSION_STRING in const.py")
+    else:
+        print("VERSION_STRING already patched by build system")
 
     # Add the src directory to the Python path for cx_Freeze
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -168,5 +180,7 @@ except Exception as e:
     print(f"Error building the application: {e}")
     raise e
 finally:
-    # Revert the const.py file to its original state
-    revert_const_file()
+    # Revert the const.py file to its original state only if we patched it
+    if not already_patched:
+        revert_const_file()
+        print("Reverted VERSION_STRING in const.py")

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -3,6 +3,7 @@ import pkgutil
 from enum import Enum
 from typing import Dict, List, Type
 from providers.analysis import AnalyzerBase, AnalyzerCategory
+from util.debug import is_debug_mode
 from util.logging import log
 
 """
@@ -28,8 +29,15 @@ def get_analyzers_by_category(category: AnalyzerCategory) -> List[Type[AnalyzerB
 
     Returns:
         List of analyzer classes for that category, or empty list if none found
+        (Filters out debug_only analyzers when debug mode is OFF)
     """
-    return PROVIDER_REGISTRY[ProviderType.ANALYZER].get(category, [])
+    analyzers = PROVIDER_REGISTRY[ProviderType.ANALYZER].get(category, [])
+
+    # Filter out debug_only analyzers when debug mode is disabled
+    if not is_debug_mode():
+        analyzers = [a for a in analyzers if not getattr(a, 'debug_only', False)]
+
+    return analyzers
 
 
 def get_all_categories(provider_type: ProviderType) -> List[AnalyzerCategory]:

--- a/src/providers/analysis/_manifest.py
+++ b/src/providers/analysis/_manifest.py
@@ -7,15 +7,19 @@ is explicitly imported here, which triggers their self-registration via
 the register_analyzer() calls.
 
 When adding a new analyzer, add its import to this file.
+
+DEBUG_ONLY marker:
+Lines marked with # DEBUG_ONLY are removed from release builds by the build system.
+This allows excluding analyzers with heavy dependencies (like scipy) from release builds.
 """
 
 # BPM analyzers
 from providers.analysis.bpm import stub_bpm
 from providers.analysis.bpm import aubio_bpm
-from providers.analysis.bpm import multiband_spectral_bpm
+from providers.analysis.bpm import multiband_spectral_bpm  # DEBUG_ONLY
 
 # Key analyzers
-from providers.analysis.key import wavelet_key_analyzer
+from providers.analysis.key import wavelet_key_analyzer  # DEBUG_ONLY
 
 # Fingerprint analyzers
 # (none yet)

--- a/src/providers/analysis/base.py
+++ b/src/providers/analysis/base.py
@@ -68,6 +68,7 @@ class AnalyzerBase(ABC):
     description: str = ""
     category: str = "uncategorized"
     version: str = "1.0.0"
+    debug_only: bool = False  # If True, this analyzer is only available in debug builds
 
     def __init__(self, media_file, options: Optional[Dict[str, Any]] = None):
         """

--- a/src/providers/analysis/bpm/multiband_spectral_bpm.py
+++ b/src/providers/analysis/bpm/multiband_spectral_bpm.py
@@ -703,8 +703,8 @@ class MultibandSpectralBPMAnalyzer(AnalyzerBase):
     name = "Multiband Spectral BPM Analyzer (RE3)"
     description = "Multi-band spectral analysis (ported from RapidEvolution3)"
     category = "bpm"
+    debug_only = True  # Heavy computation, excluded from release builds
     version = "1.0.0"
-    debug_only = True
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/bpm/stub_bpm.py
+++ b/src/providers/analysis/bpm/stub_bpm.py
@@ -31,6 +31,7 @@ class StubBPMAnalyzer(AnalyzerBase):
     description = "Test analyzer that returns a fixed BPM value"
     category = "bpm"
     version = "0.1.0"
+    debug_only = True
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/key/wavelet_key_analyzer.py
+++ b/src/providers/analysis/key/wavelet_key_analyzer.py
@@ -47,6 +47,7 @@ class WaveletKeyAnalyzer(AnalyzerBase):
     name = "Wavelet Key Analyzer"
     description = "Continuous Wavelet Transform-based key detection (adapted from RapidEvolution3)"
     category = "key"
+    debug_only = True  # Heavy computation, excluded from release builds
     version = "1.0.0"
 
     def analyze(self) -> AnalyzerResult:

--- a/src/util/const.py
+++ b/src/util/const.py
@@ -150,4 +150,6 @@ IN_GITHUB_RUNNER = (os.getenv("GITHUB_ACTIONS") == "true")
 
 MOD_TYPE_ANALYZER = "Analyzer"
 
-VERSION_STRING = None # VERSION_STRING is updated dynamically by the build system; leave this set to None
+# Build mode configuration - patched by build system
+IS_DEBUG_BUILD = True  # Default to debug mode; build system patches this for release builds
+VERSION_STRING = None  # VERSION_STRING is updated dynamically by the build system; leave this set to None

--- a/src/util/const.py
+++ b/src/util/const.py
@@ -151,5 +151,5 @@ IN_GITHUB_RUNNER = (os.getenv("GITHUB_ACTIONS") == "true")
 MOD_TYPE_ANALYZER = "Analyzer"
 
 # Build mode configuration - patched by build system
-IS_DEBUG_BUILD = True  # Default to debug mode; build system patches this for release builds
+IS_DEBUG_BUILD = False  # Default to debug mode; build system patches this for release builds
 VERSION_STRING = None  # VERSION_STRING is updated dynamically by the build system; leave this set to None

--- a/src/util/debug.py
+++ b/src/util/debug.py
@@ -1,0 +1,35 @@
+"""
+Debug Mode State Manager
+
+Manages runtime debug mode state for the application.
+Debug mode controls:
+- Log verbosity (DEBUG vs INFO)
+- Debug menu visibility in GUI
+- Debug-only analyzer availability
+"""
+
+from util.const import IS_DEBUG_BUILD
+
+# Global debug mode state - initialized from build constant
+_debug_mode_enabled = IS_DEBUG_BUILD
+
+
+def is_debug_mode() -> bool:
+    """
+    Check if debug mode is currently enabled.
+
+    Returns:
+        True if debug mode is enabled, False otherwise
+    """
+    return _debug_mode_enabled
+
+
+def set_debug_mode(enabled: bool) -> None:
+    """
+    Set the debug mode state.
+
+    Args:
+        enabled: True to enable debug mode, False to disable
+    """
+    global _debug_mode_enabled
+    _debug_mode_enabled = enabled

--- a/src/util/logging.py
+++ b/src/util/logging.py
@@ -8,14 +8,38 @@ def create_logger(log_name='YAAMT', log_level=logging.DEBUG):
 
 log = create_logger()
 
-def configure_logger(use_formatter=True):
+# Log level string to logging constant mapping
+LOG_LEVEL_MAP = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL
+}
+
+def configure_logger(use_formatter: bool = True, log_level: str = 'info'):
+    """
+    Configure the logger with the specified settings.
+
+    Args:
+        use_formatter: If True, use a formatted output (default: True)
+        log_level: Log level as a string: 'debug', 'info', 'warning', 'error', 'critical' (default: 'info')
+    """
+    # Map log level string to logging constant
+    level = LOG_LEVEL_MAP.get(log_level.lower(), logging.INFO)
+
     hand = logging.StreamHandler(sys.stderr)
+    hand.setLevel(level)
+
     if use_formatter:
         hand.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(filename)s:%(lineno)d %(funcName)s: %(message)s', "%Y%m%d-%H%M%S"))
-    
+
     if log.hasHandlers():
         log.handlers.clear()
     log.addHandler(hand)
     log.propagate = False
+
+    # Also set the logger level
+    log.setLevel(level)
 
 configure_logger()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -21,6 +21,7 @@ from models.settings import settings, FileListSettings, ColumnSettings
 from models.edit_manager import EditManager
 from delegates.editable_metadata_delegate import EditableMetadataDelegate
 from util.const import KEY_IS_MEDIA, KEY_FILE_PATH
+from util.debug import is_debug_mode
 from util.logging import log
 from providers import get_all_categories, ProviderType
 from workers.analyzer_dispatcher import AnalyzerDispatcher
@@ -384,9 +385,10 @@ class MainWindow(QMainWindow):
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.action_show_playback_panel)
 
-        # Debug Menu
-        debug_menu = self.menuBar().addMenu("&Debug")
-        self._create_debug_menu(debug_menu)
+        # Debug Menu (only shown if debug mode is enabled)
+        if is_debug_mode():
+            debug_menu = self.menuBar().addMenu("&Debug")
+            self._create_debug_menu(debug_menu)
 
         # Help Menu
         help_menu = self.menuBar().addMenu("&Help")

--- a/src/yaamt-gui.py
+++ b/src/yaamt-gui.py
@@ -4,14 +4,29 @@ import argparse
 import logging
 from PySide6.QtWidgets import QApplication
 from windows.main_window import MainWindow
-from util.logging import create_logger, log
+from util.const import IS_DEBUG_BUILD
+from util.debug import set_debug_mode, is_debug_mode
+from util.logging import create_logger, log, configure_logger
 
 
 def run_gui():
     """Initializes and runs the GUI application."""
     parser = argparse.ArgumentParser(description="Audio Metadata Tool")
     parser.add_argument("path", nargs='?', default=None, help="The starting path for the file browser.")
+    parser.add_argument('--debug', action='store_true', default=None,
+                        help=f'Enable debug mode (default: {"ON" if IS_DEBUG_BUILD else "OFF"})')
     args = parser.parse_args()
+
+    # Handle debug mode
+    # If --debug is not specified (None), use IS_DEBUG_BUILD default
+    debug_mode = args.debug if args.debug is not None else IS_DEBUG_BUILD
+    set_debug_mode(debug_mode)
+
+    # Determine log level based on debug mode (extensible for future --log-level flag)
+    log_level = 'debug' if is_debug_mode() else 'info'
+
+    # Configure logging
+    configure_logger(use_formatter=True, log_level=log_level)
 
     log.info("Starting QT application...")
     app = QApplication(sys.argv)

--- a/src/yaamt-gui.py
+++ b/src/yaamt-gui.py
@@ -13,8 +13,7 @@ def run_gui():
     """Initializes and runs the GUI application."""
     parser = argparse.ArgumentParser(description="Audio Metadata Tool")
     parser.add_argument("path", nargs='?', default=None, help="The starting path for the file browser.")
-    parser.add_argument('--debug', action='store_true', default=None,
-                        help=f'Enable debug mode (default: {"ON" if IS_DEBUG_BUILD else "OFF"})')
+    parser.add_argument('--debug', action='store_true', default=1, help=f'Enable debug mode (default)')
     args = parser.parse_args()
 
     # Handle debug mode

--- a/src/yaamt.py
+++ b/src/yaamt.py
@@ -22,7 +22,8 @@ from models.settings import settings as qsettings
 from providers import get_analyzer_by_name, get_analyzers_by_category, AnalyzerCategory
 from providers.analysis.base import AnalyzerBase
 from workers.analyzer_dispatcher import AnalyzerDispatcher
-from util.const import ALL_TAGS
+from util.const import ALL_TAGS, IS_DEBUG_BUILD
+from util.debug import set_debug_mode, is_debug_mode
 from util.logging import log, configure_logger
 from util.version import get_version
 from util.cli_formatters import (
@@ -452,6 +453,8 @@ def main():
     # Global options
     parser.add_argument('--version', action='store_true', help='Show version and exit')
     parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
+    parser.add_argument('--debug', action='store_true', default=None,
+                        help=f'Enable debug mode (default: {"ON" if IS_DEBUG_BUILD else "OFF"})')
 
     # Subcommands
     subparsers = parser.add_subparsers(dest='command', help='Command to execute')
@@ -523,9 +526,19 @@ def main():
         print(get_version())
         return SYS_RETURN_SUCCESS
 
+    # Handle debug mode
+    # If --debug is not specified (None), use IS_DEBUG_BUILD default
+    debug_mode = args.debug if args.debug is not None else IS_DEBUG_BUILD
+    set_debug_mode(debug_mode)
+
+    # Determine log level based on debug mode (extensible for future --log-level flag)
+    log_level = 'debug' if is_debug_mode() else 'info'
+
     # Configure logging
     if args.verbose:
-        configure_logger(use_formatter=True)
+        configure_logger(use_formatter=True, log_level=log_level)
+    else:
+        configure_logger(use_formatter=True, log_level=log_level)
 
     # Handle analyze command specially to add dynamic options
     if args.command == 'analyze' and hasattr(args, 'analyzer'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,10 @@ project_root = Path(__file__).parent.parent
 # Add the src directory to the Python path
 sys.path.insert(0, str(project_root / "src"))
 
+# Enable debug mode for all tests to ensure debug-only analyzers are available
+from util.debug import set_debug_mode
+set_debug_mode(True)
+
 @pytest.fixture(scope="session")
 def qapp():
     return QApplication.instance() or QApplication([])

--- a/tests/providers/analysis/key/test_wavelet_key_analyzer.py
+++ b/tests/providers/analysis/key/test_wavelet_key_analyzer.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from unittest.mock import Mock, patch, PropertyMock
 
-from util.const import IN_GITHUB_RUNNER, KEY_TAG_GENERIC, KEY_INITIAL_KEY
+from util.const import IN_GITHUB_RUNNER, KEY_TAG_GENERIC, KEY_INITIAL_KEY, PROJECT_ROOT
 from providers.analysis import AnalyzerCategory
 from providers import get_analyzers_by_category, get_analyzer_by_name
 
@@ -398,7 +398,7 @@ class TestMusicalKeyAnalyzerIntegration:
     def temp_fixture(self):
         """Create a temporary copy of a test fixture for safe testing."""
         # Use one of the drum loop fixtures
-        fixture_path = Path("tests/fixtures/metadata/lyjia_dnb019_175bpm.wav")
+        fixture_path = PROJECT_ROOT / "tests" / "fixtures" / "metadata" / "lyjia_dnb019_175bpm.wav"
 
         # Create temp file
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
@@ -476,7 +476,7 @@ class TestMusicalKeyAnalyzerIntegration:
     def test_analyze_real_harmonic_content(self):
         """Test analyzer on real audio with known musical key (C minor progression)."""
         # This file contains a C minor chord progression (i-v-VI-iv)
-        fixture_path = Path("tests/fixtures/metadata/Cmin_5A_i-v-VI-iv.mp3")
+        fixture_path = PROJECT_ROOT / "tests" / "fixtures" / "metadata" / "Cmin_5A_i-v-VI-iv.mp3"
 
         if not fixture_path.exists():
             pytest.skip(f"Test fixture not found: {fixture_path}")

--- a/yaamt-gui.bat
+++ b/yaamt-gui.bat
@@ -1,0 +1,5 @@
+@echo off
+REM YAAMT GUI launcher for Windows
+REM This script activates the virtual environment and runs the YAAMT GUI
+
+.venv\Scripts\python.exe src\yaamt-gui.py %*

--- a/yaamt-gui.sh
+++ b/yaamt-gui.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# YAAMT GUI launcher for Linux/macOS
+# This script activates the virtual environment and runs the YAAMT GUI
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/.venv/bin/python" "$SCRIPT_DIR/src/yaamt-gui.py" "$@"

--- a/yaamt.bat
+++ b/yaamt.bat
@@ -1,0 +1,5 @@
+@echo off
+REM YAAMT CLI launcher for Windows
+REM This script activates the virtual environment and runs the YAAMT CLI
+
+.venv\Scripts\python.exe src\yaamt.py %*

--- a/yaamt.sh
+++ b/yaamt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# YAAMT CLI launcher for Linux/macOS
+# This script activates the virtual environment and runs the YAAMT CLI
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/.venv/bin/python" "$SCRIPT_DIR/src/yaamt.py" "$@"


### PR DESCRIPTION
## Summary

Implements a comprehensive debug mode system that enables conditional features and build configurations for debug vs release builds, as specified in `doc/designs/debug-mode.md`.

## Key Features

### Runtime Debug Mode
- `--debug` flag for both CLI (`yaamt.py`) and GUI (`yaamt-gui.py`) applications
- Runtime debug mode state management via `util/debug.py`
- Log level automatically set based on debug mode (DEBUG when on, INFO when off)
- Debug menu in GUI only visible when debug mode is enabled

### Build-Time Configuration
- `IS_DEBUG_BUILD` constant in `util/const.py` (default: True)
- Build system patches constant to False for release builds
- Separate output directories: `build/debug/` and `build/release/`
- `--release` flag added to `build.py` (default is debug mode)

### Debug-Only Analyzers
- New `debug_only` attribute on `AnalyzerBase` class
- Runtime filtering excludes debug-only analyzers when debug mode is OFF
- Marked `multiband_spectral_bpm` and `wavelet_key_analyzer` as debug-only
- `# DEBUG_ONLY` markers in `_manifest.py` stripped during release builds

### Build Workspace System
- **`create_build_workspace()`** - Copies source tree to temp directory
- **`prepare_source_for_build()`** - Patches constants and removes debug-only code
- **`cleanup_build_workspace()`** - Cleans up on success, preserves on failure
- Prevents corruption of source tree during builds

## Components Modified

### Core Infrastructure
- `src/util/const.py` - Added IS_DEBUG_BUILD constant
- `src/util/debug.py` (NEW) - Runtime debug mode state management
- `src/util/logging.py` - Added log_level parameter

### Application Entrypoints
- `src/yaamt.py` - Added --debug flag
- `src/yaamt-gui.py` - Added --debug flag
- `src/windows/main_window.py` - Conditional debug menu visibility

### Analyzer System
- `src/providers/analysis/base.py` - Added debug_only attribute
- `src/providers/__init__.py` - Runtime filtering for debug-only analyzers
- `src/providers/analysis/_manifest.py` - DEBUG_ONLY markers
- `src/providers/analysis/bpm/multiband_spectral_bpm.py` - Marked debug_only
- `src/providers/analysis/key/wavelet_key_analyzer.py` - Marked debug_only

### Build System
- `build.py` - Implemented build workspace system and --release flag
- `setup.py` - Updated to work with new build system

## Testing

All integration tests pass:
- ✅ Debug mode state management
- ✅ Logging configuration
- ✅ Build constant
- ✅ Analyzer manifest markers
- ✅ Build workspace functions

## Usage Examples

### Debug Mode (Default)
```bash
# CLI with debug logging
python src/yaamt.py --debug list analyzers

# GUI with debug menu visible
python src/yaamt-gui.py --debug

# Build debug version
python build.py