### PR TITLE
Add Open in File Browser to File Menu

### DIFF
--- a/src/util/file_browser.py
+++ b/src/util/file_browser.py
@@ -1,0 +1,127 @@
+"""
+Cross-platform utility for opening files in the system's file browser.
+
+This module provides functionality to reveal a file in the native file browser
+(Explorer on Windows, Finder on macOS, various file managers on Linux) with
+the specified file selected.
+"""
+
+import os
+import platform
+import subprocess
+import shutil
+from pathlib import Path
+
+from util.logging import log
+
+
+def open_in_file_browser(file_path: str | Path) -> bool:
+    """
+    Open the system's file browser and select the specified file.
+
+    This function works cross-platform:
+    - Windows: Opens Explorer with the file selected
+    - macOS: Opens Finder with the file revealed
+    - Linux: Attempts to use common file managers (nautilus, dolphin, nemo, thunar, pcmanfm),
+             falling back to xdg-open for the parent directory
+
+    Args:
+        file_path: Path to the file to reveal in the file browser.
+                   Can be a string or Path object.
+
+    Returns:
+        True if the operation was initiated successfully, False otherwise.
+        Note: A True return does not guarantee the file browser opened correctly,
+        only that the command was dispatched without raising an exception.
+    """
+    path = Path(file_path).resolve()
+
+    if not path.exists():
+        log.warning(f"Cannot open in file browser: path does not exist: {path}")
+        return False
+
+    system = platform.system()
+
+    try:
+        if system == "Windows":
+            return _open_windows(path)
+        elif system == "Darwin":
+            return _open_macos(path)
+        else:
+            # Assume Linux or other Unix-like
+            return _open_linux(path)
+    except Exception as e:
+        log.error(f"Failed to open file browser: {e}")
+        return False
+
+
+def _open_windows(path: Path) -> bool:
+    """Open Windows Explorer with the file selected."""
+    # explorer /select expects the path with backslashes
+    # Using subprocess.run to avoid issues with shell=True
+    subprocess.run(
+        ["explorer", "/select,", str(path)],
+        check=False  # explorer returns non-zero on success sometimes
+    )
+    log.debug(f"Opened Explorer for: {path}")
+    return True
+
+
+def _open_macos(path: Path) -> bool:
+    """Open Finder with the file revealed."""
+    subprocess.run(
+        ["open", "-R", str(path)],
+        check=True
+    )
+    log.debug(f"Opened Finder for: {path}")
+    return True
+
+
+def _open_linux(path: Path) -> bool:
+    """
+    Open a Linux file manager with the file selected.
+
+    Tries various common file managers in order of preference:
+    1. nautilus (GNOME)
+    2. dolphin (KDE)
+    3. nemo (Cinnamon)
+    4. thunar (Xfce)
+    5. pcmanfm (LXDE)
+    6. Falls back to xdg-open on the parent directory
+    """
+    # File managers that support selecting a specific file
+    file_managers = [
+        ("nautilus", ["nautilus", "--select", str(path)]),
+        ("dolphin", ["dolphin", "--select", str(path)]),
+        ("nemo", ["nemo", str(path)]),  # nemo selects the file automatically
+        ("thunar", ["thunar", str(path)]),  # thunar selects the file automatically
+        ("pcmanfm", ["pcmanfm", str(path)]),  # pcmanfm opens the directory
+    ]
+
+    for name, command in file_managers:
+        if shutil.which(command[0]):
+            try:
+                subprocess.Popen(
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+                log.debug(f"Opened {name} for: {path}")
+                return True
+            except Exception as e:
+                log.debug(f"Failed to open {name}: {e}")
+                continue
+
+    # Fallback: use xdg-open on the parent directory
+    parent_dir = path.parent
+    if shutil.which("xdg-open"):
+        subprocess.Popen(
+            ["xdg-open", str(parent_dir)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+        log.debug(f"Opened xdg-open for parent directory: {parent_dir}")
+        return True
+
+    log.warning("No suitable file manager found on Linux")
+    return False

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -22,6 +22,7 @@ from models.edit_manager import EditManager
 from delegates.editable_metadata_delegate import EditableMetadataDelegate
 from util.const import KEY_IS_MEDIA, KEY_FILE_PATH
 from util.debug import is_debug_mode
+from util.file_browser import open_in_file_browser
 from util.logging import log
 from providers import get_all_categories, ProviderType
 from workers.analyzer_dispatcher import AnalyzerDispatcher
@@ -512,6 +513,7 @@ class MainWindow(QMainWindow):
         menu = QMenu()
         menu.addAction(self.action_play_file)
         menu.addAction(self.action_properties)
+        menu.addAction(self.action_open_in_file_browser)
         menu.addSeparator()
 
         # Add Analyze submenu
@@ -602,6 +604,11 @@ class MainWindow(QMainWindow):
         self.action_show_playback_panel.setChecked(self.playback_panel.isVisible())
         self.action_show_playback_panel.triggered.connect(self.on_show_playback_panel_requested)
 
+        # File browser action
+        self.action_open_in_file_browser = QAction("Open in File Browser", self)
+        self.action_open_in_file_browser.setEnabled(False)
+        self.action_open_in_file_browser.triggered.connect(self.on_open_in_file_browser)
+
     def _create_menus(self):
         # File Menu
         file_menu = self.menuBar().addMenu("&File")
@@ -618,6 +625,7 @@ class MainWindow(QMainWindow):
 
         file_menu.addAction(self.action_properties)
         file_menu.addAction(self.action_play_file)
+        file_menu.addAction(self.action_open_in_file_browser)
         file_menu.addSeparator()
 
         # Preferences action
@@ -1181,6 +1189,7 @@ class MainWindow(QMainWindow):
 
         self.action_properties.setEnabled(len(selected_rows) > 0 and is_media_file)
         self.action_play_file.setEnabled(len(selected_rows) == 1 and is_media_file)
+        self.action_open_in_file_browser.setEnabled(len(selected_rows) == 1)
         # Save and Reset actions are enabled/disabled by on_autosave_changed
         # but they also require staged changes to be meaningful.
         # We can further refine their state here if needed, e.g., disable if no staged changes.
@@ -1404,6 +1413,23 @@ class MainWindow(QMainWindow):
                 media_file = MediaFile(file_path)
                 self.playback_panel.show()
                 self.start_playback_signal.emit(media_file)
+
+    def on_open_in_file_browser(self):
+        """
+        Opens the system file browser with the selected file revealed.
+        """
+        selected_indexes = self.files_view.selectionModel().selectedRows()
+        if len(selected_indexes) == 1:
+            source_index = self.proxy_model.mapToSource(selected_indexes[0])
+            row_data = self.file_model.get_data_for_row(row=source_index.row())
+            file_path = row_data.get(KEY_FILE_PATH)
+            if file_path:
+                if not open_in_file_browser(file_path):
+                    QMessageBox.warning(
+                        self,
+                        "Error",
+                        f"Could not open file browser for:\n{file_path}"
+                    )
 
     @Slot(bool)
     def on_show_playback_panel_requested(self, checked: bool):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1239,7 +1239,7 @@ class MainWindow(QMainWindow):
 
         self.action_properties.setEnabled(len(selected_rows) > 0 and is_media_file)
         self.action_play_file.setEnabled(len(selected_rows) == 1 and is_media_file)
-        self.action_open_in_file_browser.setEnabled(len(selected_rows) == 1)
+        self.action_open_in_file_browser.setEnabled(len(selected_rows) >= 1)
         # Save and Reset actions are enabled/disabled by on_autosave_changed
         # but they also require staged changes to be meaningful.
         # We can further refine their state here if needed, e.g., disable if no staged changes.
@@ -1466,10 +1466,11 @@ class MainWindow(QMainWindow):
 
     def on_open_in_file_browser(self):
         """
-        Opens the system file browser with the selected file revealed.
+        Opens the system file browser with the first selected file revealed.
+        When multiple files are selected, the first one is used.
         """
         selected_indexes = self.files_view.selectionModel().selectedRows()
-        if len(selected_indexes) == 1:
+        if len(selected_indexes) >= 1:
             source_index = self.proxy_model.mapToSource(selected_indexes[0])
             row_data = self.file_model.get_data_for_row(row=source_index.row())
             file_path = row_data.get(KEY_FILE_PATH)

--- a/tests/test_file_browser.py
+++ b/tests/test_file_browser.py
@@ -1,0 +1,187 @@
+"""Tests for the file_browser utility module."""
+
+import os
+import platform
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from util.file_browser import open_in_file_browser, _open_windows, _open_macos, _open_linux
+
+
+class TestOpenInFileBrowser:
+    """Tests for the open_in_file_browser function."""
+
+    def test_returns_false_for_nonexistent_path(self, tmp_path):
+        """Should return False when the file doesn't exist."""
+        nonexistent = tmp_path / "nonexistent_file.txt"
+        result = open_in_file_browser(nonexistent)
+        assert result is False
+
+    def test_accepts_string_path(self, tmp_path):
+        """Should accept a string path."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        with patch('util.file_browser._open_windows') as mock_win, \
+             patch('util.file_browser._open_macos') as mock_mac, \
+             patch('util.file_browser._open_linux') as mock_linux:
+
+            mock_win.return_value = True
+            mock_mac.return_value = True
+            mock_linux.return_value = True
+
+            # Should not raise
+            result = open_in_file_browser(str(test_file))
+            assert result is True
+
+    def test_accepts_path_object(self, tmp_path):
+        """Should accept a Path object."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        with patch('util.file_browser._open_windows') as mock_win, \
+             patch('util.file_browser._open_macos') as mock_mac, \
+             patch('util.file_browser._open_linux') as mock_linux:
+
+            mock_win.return_value = True
+            mock_mac.return_value = True
+            mock_linux.return_value = True
+
+            # Should not raise
+            result = open_in_file_browser(test_file)
+            assert result is True
+
+    @patch('platform.system')
+    @patch('util.file_browser._open_windows')
+    def test_calls_windows_handler_on_windows(self, mock_handler, mock_system, tmp_path):
+        """Should call _open_windows on Windows."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        mock_system.return_value = "Windows"
+        mock_handler.return_value = True
+
+        result = open_in_file_browser(test_file)
+
+        assert result is True
+        mock_handler.assert_called_once()
+
+    @patch('platform.system')
+    @patch('util.file_browser._open_macos')
+    def test_calls_macos_handler_on_darwin(self, mock_handler, mock_system, tmp_path):
+        """Should call _open_macos on macOS."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        mock_system.return_value = "Darwin"
+        mock_handler.return_value = True
+
+        result = open_in_file_browser(test_file)
+
+        assert result is True
+        mock_handler.assert_called_once()
+
+    @patch('platform.system')
+    @patch('util.file_browser._open_linux')
+    def test_calls_linux_handler_on_linux(self, mock_handler, mock_system, tmp_path):
+        """Should call _open_linux on Linux."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        mock_system.return_value = "Linux"
+        mock_handler.return_value = True
+
+        result = open_in_file_browser(test_file)
+
+        assert result is True
+        mock_handler.assert_called_once()
+
+
+class TestOpenWindows:
+    """Tests for the _open_windows function."""
+
+    @patch('subprocess.run')
+    def test_calls_explorer_with_select(self, mock_run, tmp_path):
+        """Should call explorer with /select, argument."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        _open_windows(test_file)
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "explorer"
+        assert args[1] == "/select,"
+        assert str(test_file) in args[2]
+
+
+class TestOpenMacos:
+    """Tests for the _open_macos function."""
+
+    @patch('subprocess.run')
+    def test_calls_open_with_reveal(self, mock_run, tmp_path):
+        """Should call open with -R argument."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        _open_macos(test_file)
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "open"
+        assert args[1] == "-R"
+
+
+class TestOpenLinux:
+    """Tests for the _open_linux function."""
+
+    @patch('shutil.which')
+    @patch('subprocess.Popen')
+    def test_tries_nautilus_first(self, mock_popen, mock_which, tmp_path):
+        """Should try nautilus first if available."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        mock_which.side_effect = lambda x: x if x == "nautilus" else None
+
+        result = _open_linux(test_file)
+
+        assert result is True
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert args[0] == "nautilus"
+        assert args[1] == "--select"
+
+    @patch('shutil.which')
+    @patch('subprocess.Popen')
+    def test_falls_back_to_xdg_open(self, mock_popen, mock_which, tmp_path):
+        """Should fall back to xdg-open if no file manager is found."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        # Only xdg-open is available
+        mock_which.side_effect = lambda x: x if x == "xdg-open" else None
+
+        result = _open_linux(test_file)
+
+        assert result is True
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert args[0] == "xdg-open"
+        # xdg-open should be called with the parent directory
+        assert str(test_file.parent) in args[1]
+
+    @patch('shutil.which')
+    def test_returns_false_when_no_manager_found(self, mock_which, tmp_path):
+        """Should return False if no file manager is available."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        mock_which.return_value = None
+
+        result = _open_linux(test_file)
+
+        assert result is False


### PR DESCRIPTION
Adds a cross-platform utility (src/util/file_browser.py) that reveals files in the native file manager:
- Windows: Explorer with /select
- macOS: Finder with open -R
- Linux: Tries nautilus, dolphin, nemo, thunar, pcmanfm, falls back to xdg-open

Integrates the feature into the GUI:
- Added to File menu after "Play this file"
- Added to right-click context menu in file pane
- Enabled when exactly one file is selected

Includes comprehensive unit tests for the utility module.