### PR TITLE
Fix KeyNet model download URL and expected size type

### DIFF
--- a/src/providers/analysis/key/cnn_key.py
+++ b/src/providers/analysis/key/cnn_key.py
@@ -68,8 +68,8 @@ KEYNET_RESOURCE_ID = "keynet_model"
 KEYNET_MODEL_FILENAME = "keynet.pt"
 # Note: The model URL and checksum should be configured by the user or provided
 # by the application maintainer. For now, we support local-only mode.
-KEYNET_MODEL_URL = "https://github.com/a1ex90/MusicalKeyCNN/blob/main/checkpoints/keynet.pt"
-KEYNET_MODEL_SIZE = "1874533" # Used only for progress display on downloader
+KEYNET_MODEL_URL = "https://github.com/a1ex90/MusicalKeyCNN/raw/main/checkpoints/keynet.pt"
+KEYNET_MODEL_SIZE = 1874533  # Used only for progress display on downloader
 KEYNET_MODEL_CHECKSUM = "fc92072f1b9b19552ce3b74a9c8ce0cecb97633a12ae524ac0d93c05800e354e"  # SHA256 for validation
 
 


### PR DESCRIPTION
- Corrected the download URL for the KeyNet model to use the raw GitHub URL, ensuring the correct file content is accessed.
- Updated the `expected_size` type from string to integer to address type comparison errors.