### PR TITLE
Make provider registration more pythonic

### DIFF
--- a/build.py
+++ b/build.py
@@ -265,21 +265,44 @@ def prepare_source_for_build(temp_src_path: Path, build_mode: str, version_strin
     print(f"  Patched IS_DEBUG_BUILD = {is_debug_value}")
     print(f"  Patched VERSION_STRING = {version_string}")
 
-    # For release builds, remove DEBUG_ONLY lines from _manifest.py
+    # For release builds, remove debug-only analyzers from _manifest.py
     if build_mode == 'release':
         manifest_file = temp_src_path / 'src' / 'providers' / 'analysis' / '_manifest.py'
+        src_dir = temp_src_path / 'src'
 
         with open(manifest_file, 'r') as f:
             lines = f.readlines()
 
-        # Filter out lines with DEBUG_ONLY marker
-        filtered_lines = [line for line in lines if '# DEBUG_ONLY' not in line]
+        # Filter out imports of modules that have @analyzer(..., debug_only=True)
+        filtered_lines = []
+        removed_count = 0
+
+        for line in lines:
+            # Check if this is an import line (e.g., "from providers.analysis.bpm import stub_bpm")
+            import_match = re.match(r'^from\s+(providers\.analysis\.\w+)\s+import\s+(\w+)', line)
+            if import_match:
+                package_path = import_match.group(1)  # e.g., "providers.analysis.bpm"
+                module_name = import_match.group(2)   # e.g., "stub_bpm"
+
+                # Convert to file path
+                module_file = src_dir / package_path.replace('.', '/') / f"{module_name}.py"
+
+                if module_file.exists():
+                    with open(module_file, 'r') as f:
+                        module_content = f.read()
+
+                    # Check for @analyzer(..., debug_only=True) pattern
+                    if re.search(r'@analyzer\s*\([^)]*debug_only\s*=\s*True[^)]*\)', module_content):
+                        removed_count += 1
+                        print(f"    Excluding debug-only analyzer: {module_name}")
+                        continue  # Skip this import
+
+            filtered_lines.append(line)
 
         with open(manifest_file, 'w') as f:
             f.writelines(filtered_lines)
 
-        removed_count = len(lines) - len(filtered_lines)
-        print(f"  Removed {removed_count} DEBUG_ONLY analyzer(s) from manifest")
+        print(f"  Removed {removed_count} debug-only analyzer(s) from manifest")
 
 
 def cleanup_build_workspace(temp_path: Path) -> None:

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -110,7 +110,7 @@ def register_analyzer(category: AnalyzerCategory, klass: Type[AnalyzerBase]):
         log.warning(f"Error registering resources for {klass.__name__}: {e}")
 
 
-def analyzer(category: AnalyzerCategory) -> Callable[[Type[AnalyzerBase]], Type[AnalyzerBase]]:
+def analyzer(category: AnalyzerCategory, debug_only: bool = False) -> Callable[[Type[AnalyzerBase]], Type[AnalyzerBase]]:
     """
     Class decorator that registers an analyzer with the provider registry.
 
@@ -119,10 +119,17 @@ def analyzer(category: AnalyzerCategory) -> Callable[[Type[AnalyzerBase]], Type[
         class MyBPMAnalyzer(AnalyzerBase):
             ...
 
+        @analyzer(AnalyzerCategory.BPM, debug_only=True)
+        class ExperimentalAnalyzer(AnalyzerBase):
+            ...
+
     :param category: The category under which the analyzer should be registered.
+    :param debug_only: If True, analyzer is only available in debug builds (default: False).
     :return: A decorator function that registers the class and returns it unchanged.
     """
     def decorator(klass: Type[AnalyzerBase]) -> Type[AnalyzerBase]:
+        if debug_only:
+            klass.debug_only = True
         register_analyzer(category, klass)
         return klass
     return decorator

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 import pkgutil
 from enum import Enum
-from typing import Dict, List, Type
+from typing import Callable, Dict, List, Type
 from providers.analysis import AnalyzerBase, AnalyzerCategory
 from util.debug import is_debug_mode
 from util.logging import log
@@ -108,6 +108,24 @@ def register_analyzer(category: AnalyzerCategory, klass: Type[AnalyzerBase]):
             log.debug(f"Registered {len(resources)} resources for {klass.__name__}")
     except Exception as e:
         log.warning(f"Error registering resources for {klass.__name__}: {e}")
+
+
+def analyzer(category: AnalyzerCategory) -> Callable[[Type[AnalyzerBase]], Type[AnalyzerBase]]:
+    """
+    Class decorator that registers an analyzer with the provider registry.
+
+    Usage:
+        @analyzer(AnalyzerCategory.BPM)
+        class MyBPMAnalyzer(AnalyzerBase):
+            ...
+
+    :param category: The category under which the analyzer should be registered.
+    :return: A decorator function that registers the class and returns it unchanged.
+    """
+    def decorator(klass: Type[AnalyzerBase]) -> Type[AnalyzerBase]:
+        register_analyzer(category, klass)
+        return klass
+    return decorator
 
 def discover_providers():
     """

--- a/src/providers/analysis/_manifest.py
+++ b/src/providers/analysis/_manifest.py
@@ -4,25 +4,25 @@ Explicit manifest of all analyzer modules for static discovery.
 This file exists to support compilation with Nuitka and other bundlers that
 don't support runtime module discovery via pkgutil. Each analyzer module
 is explicitly imported here, which triggers their self-registration via
-the register_analyzer() calls.
+the @analyzer() decorator.
 
 When adding a new analyzer, add its import to this file.
 
-DEBUG_ONLY marker:
-Lines marked with # DEBUG_ONLY are removed from release builds by the build system.
-This allows excluding analyzers with heavy dependencies (like scipy) from release builds.
+Debug-only analyzers:
+Analyzers decorated with @analyzer(..., debug_only=True) are automatically
+excluded from release builds by the build system. No additional markers needed.
 """
 
 # BPM analyzers
 from providers.analysis.bpm import stub_bpm
 from providers.analysis.bpm import aubio_bpm
-from providers.analysis.bpm import re3_bpm   # DEBUG_ONLY
-from providers.analysis.bpm import librosa_bpm # DEBUG_ONLY
+from providers.analysis.bpm import re3_bpm
+from providers.analysis.bpm import librosa_bpm
 
 # Key analyzers
-from providers.analysis.key import re3_key   # DEBUG_ONLY
-from providers.analysis.key import librosa_key # DEBUG_ONLY
-from providers.analysis.key import musical_cnn_key # DEBUG_ONLY
+from providers.analysis.key import re3_key
+from providers.analysis.key import librosa_key
+from providers.analysis.key import musical_cnn_key
 
 # Fingerprint analyzers
 # (none yet)

--- a/src/providers/analysis/_manifest.py
+++ b/src/providers/analysis/_manifest.py
@@ -22,7 +22,7 @@ from providers.analysis.bpm import librosa_bpm # DEBUG_ONLY
 # Key analyzers
 from providers.analysis.key import re3_key   # DEBUG_ONLY
 from providers.analysis.key import librosa_key # DEBUG_ONLY
-from providers.analysis.key import cnn_key # DEBUG_ONLY
+from providers.analysis.key import musical_cnn_key # DEBUG_ONLY
 
 # Fingerprint analyzers
 # (none yet)

--- a/src/providers/analysis/bpm/aubio_bpm.py
+++ b/src/providers/analysis/bpm/aubio_bpm.py
@@ -12,12 +12,13 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QComboBox,
                                 QSpinBox, QGroupBox, QLabel)
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.logging import log
 
 
+@analyzer(AnalyzerCategory.BPM)
 class AubioBPMAnalyzer(AnalyzerBase):
     """
     BPM analyzer using aubio's tempo detection algorithm.
@@ -318,7 +319,3 @@ class AubioBPMAnalyzer(AnalyzerBase):
 
         widget.setLayout(main_layout)
         return widget
-
-
-# Register this analyzer with the BPM category
-register_analyzer(AnalyzerCategory.BPM, AubioBPMAnalyzer)

--- a/src/providers/analysis/bpm/librosa_bpm.py
+++ b/src/providers/analysis/bpm/librosa_bpm.py
@@ -19,7 +19,7 @@ from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.logging import log
 
 
-@analyzer(AnalyzerCategory.BPM)
+@analyzer(AnalyzerCategory.BPM, debug_only=True)
 class LibrosaBeatTrackingBPMAnalyzer(AnalyzerBase):
     """
     BPM analyzer using librosa's beat tracking algorithm.
@@ -40,7 +40,6 @@ class LibrosaBeatTrackingBPMAnalyzer(AnalyzerBase):
     description = "Detects tempo using librosa's beat tracking algorithm"
     category = "bpm"
     version = "1.0.0"
-    debug_only = True
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/bpm/librosa_bpm.py
+++ b/src/providers/analysis/bpm/librosa_bpm.py
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
     from PySide6.QtWidgets import QWidget
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.logging import log
 
 
+@analyzer(AnalyzerCategory.BPM)
 class LibrosaBeatTrackingBPMAnalyzer(AnalyzerBase):
     """
     BPM analyzer using librosa's beat tracking algorithm.
@@ -290,7 +291,3 @@ class LibrosaBeatTrackingBPMAnalyzer(AnalyzerBase):
 
         widget.setLayout(main_layout)
         return widget
-
-
-# Register this analyzer with the BPM category
-register_analyzer(AnalyzerCategory.BPM, LibrosaBeatTrackingBPMAnalyzer)

--- a/src/providers/analysis/bpm/re3_bpm.py
+++ b/src/providers/analysis/bpm/re3_bpm.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QLabel, QSpinBox,
 
 from models.settings import get_qsettings
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.logging import log
@@ -682,6 +682,7 @@ class SubBandSeparator:
         return returnval
 
 
+@analyzer(AnalyzerCategory.BPM)
 class RE3MultibandSpectralBPMAnalyzer(AnalyzerBase):
     """
     BPM analyzer using the RapidEvolution3 algorithm.
@@ -947,7 +948,3 @@ class RE3MultibandSpectralBPMAnalyzer(AnalyzerBase):
 
         widget.setLayout(main_layout)
         return widget
-
-
-# Register this analyzer with the BPM category
-register_analyzer(AnalyzerCategory.BPM, RE3MultibandSpectralBPMAnalyzer)

--- a/src/providers/analysis/bpm/re3_bpm.py
+++ b/src/providers/analysis/bpm/re3_bpm.py
@@ -682,7 +682,7 @@ class SubBandSeparator:
         return returnval
 
 
-@analyzer(AnalyzerCategory.BPM)
+@analyzer(AnalyzerCategory.BPM, debug_only=True)
 class RE3MultibandSpectralBPMAnalyzer(AnalyzerBase):
     """
     BPM analyzer using the RapidEvolution3 algorithm.
@@ -703,7 +703,6 @@ class RE3MultibandSpectralBPMAnalyzer(AnalyzerBase):
     name = "RE3 Spectral BPM Analyzer"
     description = "Multi-band spectral analysis algorithm adapted from RapidEvolution3 by DJ Qualia."
     category = "bpm"
-    debug_only = True  # Heavy computation, excluded from release builds
     version = "1.0.0"
 
     def analyze(self) -> AnalyzerResult:

--- a/src/providers/analysis/bpm/stub_bpm.py
+++ b/src/providers/analysis/bpm/stub_bpm.py
@@ -16,7 +16,7 @@ from util.analyzer_options import AnalyzerOption
 from util.logging import log
 
 
-@analyzer(AnalyzerCategory.BPM)
+@analyzer(AnalyzerCategory.BPM, debug_only=True)
 class StubBPMAnalyzer(AnalyzerBase):
     """
     A stub analyzer for testing purposes.
@@ -32,7 +32,6 @@ class StubBPMAnalyzer(AnalyzerBase):
     description = "Test analyzer that returns a fixed BPM value"
     category = "bpm"
     version = "0.1.0"
-    debug_only = True
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/bpm/stub_bpm.py
+++ b/src/providers/analysis/bpm/stub_bpm.py
@@ -11,11 +11,12 @@ from typing import Optional, List
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QSpinBox, QFormLayout
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from util.analyzer_options import AnalyzerOption
 from util.logging import log
 
 
+@analyzer(AnalyzerCategory.BPM)
 class StubBPMAnalyzer(AnalyzerBase):
     """
     A stub analyzer for testing purposes.
@@ -89,5 +90,3 @@ class StubBPMAnalyzer(AnalyzerBase):
 
     # Note: get_settings_widget() is inherited from AnalyzerBase
     # and will auto-generate from get_options_metadata() (returns None since no options)
-
-register_analyzer(AnalyzerCategory.BPM, StubBPMAnalyzer)

--- a/src/providers/analysis/key/librosa_key.py
+++ b/src/providers/analysis/key/librosa_key.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from PySide6.QtWidgets import QWidget
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.const import KEY_INITIAL_KEY
@@ -29,6 +29,7 @@ MINOR_PROFILE = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 
 PITCH_CLASSES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
 
+@analyzer(AnalyzerCategory.KEY)
 class LibrosaChromagramKeyAnalyzer(AnalyzerBase):
     """
     Musical key analyzer using librosa chromagram and Krumhansl-Schmuckler algorithm.
@@ -340,7 +341,3 @@ class LibrosaChromagramKeyAnalyzer(AnalyzerBase):
 
         widget.setLayout(main_layout)
         return widget
-
-
-# Register this analyzer with the Key category
-register_analyzer(AnalyzerCategory.KEY, LibrosaChromagramKeyAnalyzer)

--- a/src/providers/analysis/key/librosa_key.py
+++ b/src/providers/analysis/key/librosa_key.py
@@ -29,7 +29,7 @@ MINOR_PROFILE = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 
 PITCH_CLASSES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
 
-@analyzer(AnalyzerCategory.KEY)
+@analyzer(AnalyzerCategory.KEY, debug_only=True)
 class LibrosaChromagramKeyAnalyzer(AnalyzerBase):
     """
     Musical key analyzer using librosa chromagram and Krumhansl-Schmuckler algorithm.
@@ -51,7 +51,6 @@ class LibrosaChromagramKeyAnalyzer(AnalyzerBase):
     description = "Detects musical key using librosa's chromagram and Krumhansl-Schmuckler algorithm"
     category = "key"
     version = "1.0.0"
-    debug_only = True
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/key/musical_cnn_key.py
+++ b/src/providers/analysis/key/musical_cnn_key.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from PySide6.QtWidgets import QWidget
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.const import KEY_INITIAL_KEY
@@ -73,6 +73,7 @@ KEYNET_MODEL_SIZE = 1874533  # Used only for progress display on downloader
 KEYNET_MODEL_CHECKSUM = "fc92072f1b9b19552ce3b74a9c8ce0cecb97633a12ae524ac0d93c05800e354e"  # SHA256 for validation
 
 
+@analyzer(AnalyzerCategory.KEY)
 class MusicalKeyCNNAnalyzer(AnalyzerBase):
     """
     Musical key analyzer using a Convolutional Neural Network.
@@ -630,7 +631,3 @@ class MusicalKeyCNNAnalyzer(AnalyzerBase):
 
         # Set initial status
         update_status()
-
-
-# Register this analyzer with the Key category
-register_analyzer(AnalyzerCategory.KEY, MusicalKeyCNNAnalyzer)

--- a/src/providers/analysis/key/musical_cnn_key.py
+++ b/src/providers/analysis/key/musical_cnn_key.py
@@ -73,7 +73,7 @@ KEYNET_MODEL_SIZE = 1874533  # Used only for progress display on downloader
 KEYNET_MODEL_CHECKSUM = "fc92072f1b9b19552ce3b74a9c8ce0cecb97633a12ae524ac0d93c05800e354e"  # SHA256 for validation
 
 
-@analyzer(AnalyzerCategory.KEY)
+@analyzer(AnalyzerCategory.KEY, debug_only=True)
 class MusicalKeyCNNAnalyzer(AnalyzerBase):
     """
     Musical key analyzer using a Convolutional Neural Network.
@@ -105,7 +105,6 @@ class MusicalKeyCNNAnalyzer(AnalyzerBase):
     description = "Deep learning key detector using CNN (Korzeniowski & Widmer 2018)"
     category = "key"
     version = "1.0.0"
-    debug_only = True  # PyTorch cannot be compiled with nuitka
 
     def analyze(self) -> AnalyzerResult:
         """

--- a/src/providers/analysis/key/re3_key.py
+++ b/src/providers/analysis/key/re3_key.py
@@ -16,7 +16,7 @@ import numpy as np
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QGroupBox
 
 from providers.analysis import AnalyzerBase, AnalyzerResult, AnalyzerCategory
-from providers import register_analyzer
+from providers import analyzer
 from util.const import KEY_INITIAL_KEY, KEY_DIATONIC_MODE
 from util.analyzer_options import AnalyzerOption, build_widget_from_option
 from util.logging import log
@@ -29,6 +29,7 @@ from providers.analysis.key.support.wavelet import (
 )
 
 
+@analyzer(AnalyzerCategory.KEY)
 class RE3WaveletKeyAnalyzer(AnalyzerBase):
     """
     Musical key analyzer adapted from the RapidEvolution3 CWT algorithm.
@@ -531,7 +532,3 @@ class RE3WaveletKeyAnalyzer(AnalyzerBase):
         layout.addStretch()
         widget.setLayout(layout)
         return widget
-
-
-# Register this analyzer with the Key category
-register_analyzer(AnalyzerCategory.KEY, RE3WaveletKeyAnalyzer)

--- a/src/providers/analysis/key/re3_key.py
+++ b/src/providers/analysis/key/re3_key.py
@@ -29,7 +29,7 @@ from providers.analysis.key.support.wavelet import (
 )
 
 
-@analyzer(AnalyzerCategory.KEY)
+@analyzer(AnalyzerCategory.KEY, debug_only=True)
 class RE3WaveletKeyAnalyzer(AnalyzerBase):
     """
     Musical key analyzer adapted from the RapidEvolution3 CWT algorithm.
@@ -50,7 +50,6 @@ class RE3WaveletKeyAnalyzer(AnalyzerBase):
     name = "RE3 Wavelet Key Analyzer"
     description = "Continuous Wavelet Transform-based key detection algorithm adapted from RapidEvolution3 by DJ Qualia."
     category = "key"
-    debug_only = True  # Heavy computation, excluded from release builds
     version = "1.0.0"
 
     def analyze(self) -> AnalyzerResult:

--- a/src/providers/analysis/loudness/peak_meter.py
+++ b/src/providers/analysis/loudness/peak_meter.py
@@ -11,11 +11,12 @@ from typing import Optional, List
 
 from providers.audio import AudioStreamBase
 from providers.analysis import AnalyzerCategory, AnalyzerBase, AnalyzerResult
-from providers import register_analyzer
+from providers import analyzer
 from util.const import KEY_COMMENT
 from util.logging import log
 
 
+@analyzer(AnalyzerCategory.LOUDNESS)
 class PeakMeterAnalyzer(AnalyzerBase):
     """
     Analyzer that measures peak loudness (maximum sample value) in dBFS.
@@ -296,5 +297,3 @@ class PeakMeterAnalyzer(AnalyzerBase):
             return (False, "File is not readable")
 
         return (True, None)
-
-register_analyzer(AnalyzerCategory.LOUDNESS, PeakMeterAnalyzer)

--- a/tests/providers/analysis/key/test_cnn_key.py
+++ b/tests/providers/analysis/key/test_cnn_key.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from util.const import IN_GITHUB_RUNNER, KEY_INITIAL_KEY
 from providers.analysis.base import AnalyzerResult
-from providers.analysis.key.cnn_key import MusicalKeyCNNAnalyzer, KEYNET_RESOURCE_ID
+from providers.analysis.key.musical_cnn_key import MusicalKeyCNNAnalyzer, KEYNET_RESOURCE_ID
 from providers import get_analyzers_by_category
 from providers.analysis import AnalyzerCategory
 from models.media_file import MediaFile
@@ -171,7 +171,7 @@ class TestMusicalKeyCNNAnalyzerBasicBehavior:
         media_file = MediaFile(valid_audio_file, enable_write=False)
 
         # Mock resource manager to simulate missing model
-        with patch('providers.analysis.key.cnn_key.get_resource_manager') as mock_rm:
+        with patch('providers.analysis.key.musical_cnn_key.get_resource_manager') as mock_rm:
             mock_rm.return_value.is_resource_loadable.return_value = False
             analyzer = MusicalKeyCNNAnalyzer(media_file)
             result = analyzer.analyze()


### PR DESCRIPTION
Add @analyzer(category) class decorator for cleaner analyzer registration. Analyzers now declare their category at the class definition rather than with a separate function call at module end.

Also fixes test_cnn_key.py imports after cnn_key.py -> musical_cnn_key.py rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)