### PR TITLE
Fix CSV reporting issues with newlines and BPM formatting

### DIFF
--- a/src/util/cli_formatters.py
+++ b/src/util/cli_formatters.py
@@ -553,7 +553,9 @@ def write_output(content: str, output_file: Optional[str] = None) -> None:
     """
     if output_file:
         output_path = Path(output_file)
-        with open(output_path, 'w', encoding='utf-8') as f:
+        # Use newline='' to prevent double newline translation on Windows
+        # (csv module already produces appropriate line endings)
+        with open(output_path, 'w', encoding='utf-8', newline='') as f:
             f.write(content)
             f.write('\n')
     else:

--- a/src/workers/analyzer_dispatcher.py
+++ b/src/workers/analyzer_dispatcher.py
@@ -231,6 +231,52 @@ class AnalyzerWorker(QRunnable):
         self.signals.worker_finished.emit(self.worker_id, self.task)
 
 
+def _postprocess_result_data(result_data: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Postprocess analyzer result data, converting raw outputs to final values.
+
+    This handles conversions like BPM candidates to final BPM values with range
+    adjustment. Used by both tag writing and report generation to ensure
+    consistent output.
+
+    Args:
+        result_data: Raw result data dictionary from analyzer
+        options: Analyzer options dictionary (may contain bpm_min, bpm_max)
+
+    Returns:
+        Processed result data dictionary with converted values
+    """
+    if not result_data:
+        return {}
+
+    processed = result_data.copy()
+
+    # Handle BPM candidates: convert to final BPM value using range selection
+    if 'bpm_candidates' in processed:
+        candidates = processed.pop('bpm_candidates')
+        if candidates:
+            # Get BPM range from options or settings
+            min_bpm = options.get('bpm_min')
+            max_bpm = options.get('bpm_max')
+
+            # Fall back to QSettings if not in options
+            if min_bpm is None:
+                qsettings = get_qsettings()
+                min_bpm = qsettings.value(BPM_RANGE_MIN_KEY, BPM_RANGE_MIN_DEFAULT, type=int)
+            if max_bpm is None:
+                qsettings = get_qsettings()
+                max_bpm = qsettings.value(BPM_RANGE_MAX_KEY, BPM_RANGE_MAX_DEFAULT, type=int)
+
+            # Select best BPM from candidates
+            final_bpm = select_best_bpm(candidates, min_bpm, max_bpm)
+            if final_bpm is not None:
+                processed['bpm'] = final_bpm
+                log.debug(f"Selected BPM {final_bpm:.2f} from {len(candidates)} candidates "
+                         f"(range: {min_bpm}-{max_bpm})")
+
+    return processed
+
+
 class WorkerSignals(QObject):
     """
     Signals emitted by analyzer workers.
@@ -577,32 +623,8 @@ class AnalyzerDispatcher(QObject):
 
         if task.result.success and not task.result.skipped and task.result.data:
             try:
-                # Handle special case: mode field from key analyzer
-                # Mode should be appended to comments in format "Key: C (ionian)"
-                result_data = task.result.data.copy()
-
-                # Handle BPM candidates: convert to final BPM value using range selection
-                if 'bpm_candidates' in result_data:
-                    candidates = result_data.pop('bpm_candidates')
-                    if candidates:
-                        # Get BPM range from options or settings
-                        min_bpm = task.options.get('bpm_min')
-                        max_bpm = task.options.get('bpm_max')
-
-                        # Fall back to QSettings if not in options
-                        if min_bpm is None:
-                            qsettings = get_qsettings()
-                            min_bpm = qsettings.value(BPM_RANGE_MIN_KEY, BPM_RANGE_MIN_DEFAULT, type=int)
-                        if max_bpm is None:
-                            qsettings = get_qsettings()
-                            max_bpm = qsettings.value(BPM_RANGE_MAX_KEY, BPM_RANGE_MAX_DEFAULT, type=int)
-
-                        # Select best BPM from candidates
-                        final_bpm = select_best_bpm(candidates, min_bpm, max_bpm)
-                        if final_bpm is not None:
-                            result_data['bpm'] = final_bpm
-                            log.debug(f"Selected BPM {final_bpm:.2f} from {len(candidates)} candidates "
-                                     f"(range: {min_bpm}-{max_bpm})")
+                # Apply standard postprocessing (BPM candidate selection, etc.)
+                result_data = _postprocess_result_data(task.result.data, task.options)
 
                 # Note: There isn't a standard way to store diatonic mode so we're just gonna put it in comments
                 # if it exists
@@ -695,9 +717,13 @@ class AnalyzerDispatcher(QObject):
             # Build results list in the format expected by format_analysis_results
             results = []
             for task in self.completed_tasks:
+                # Apply same postprocessing as tag writing (BPM candidate selection, etc.)
+                raw_data = task.result.data if task.result and task.result.success else {}
+                processed_data = _postprocess_result_data(raw_data, task.options) if raw_data else {}
+
                 result_dict = {
                     'filepath': task.media_file.file_path,
-                    'results': task.result.data if task.result and task.result.success else {},
+                    'results': processed_data,
                     'status': 'success' if (task.result and task.result.success) else (
                         'skipped' if (task.result and task.result.skipped) else 'error'
                     ),

--- a/tests/util/test_cli_formatters.py
+++ b/tests/util/test_cli_formatters.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for CLI formatting utilities.
+
+Tests CSV output formatting, including:
+- Newline handling across platforms
+- BpmCandidate postprocessing for reports
+"""
+
+import pytest
+import tempfile
+import os
+from pathlib import Path
+
+from util.cli_formatters import (
+    _format_as_csv,
+    format_analysis_results,
+    write_output,
+)
+
+
+class TestFormatAsCsv:
+    """Tests for CSV formatting function."""
+
+    def test_basic_csv_output(self):
+        """Test basic CSV formatting with simple data."""
+        rows = [
+            {'filepath': '/path/to/file1.mp3', 'bpm': 120.0, 'status': 'success'},
+            {'filepath': '/path/to/file2.mp3', 'bpm': 128.0, 'status': 'success'},
+        ]
+        columns = ['bpm', 'status']
+
+        result = _format_as_csv(rows, columns, 'filepath')
+
+        # Should have header + 2 data rows
+        lines = result.strip().split('\n')
+        assert len(lines) == 3
+
+        # Check header
+        assert 'directory' in lines[0]
+        assert 'filename' in lines[0]
+        assert 'bpm' in lines[0]
+        assert 'status' in lines[0]
+
+    def test_csv_newlines_format(self):
+        """Test that CSV uses proper line endings (no double newlines)."""
+        rows = [
+            {'filepath': '/path/to/file.mp3', 'value': 'test'},
+        ]
+        columns = ['value']
+
+        result = _format_as_csv(rows, columns, 'filepath')
+
+        # Should not contain \r\r or double \n\n (except trailing)
+        assert '\r\r' not in result
+        # Count actual lines - should be exactly 2 (header + 1 data)
+        lines = [l for l in result.split('\n') if l.strip()]
+        assert len(lines) == 2
+
+    def test_csv_empty_rows(self):
+        """Test CSV formatting with empty rows list."""
+        result = _format_as_csv([], ['col1', 'col2'], 'filepath')
+        assert result == ""
+
+    def test_csv_special_characters_in_values(self):
+        """Test CSV properly escapes special characters."""
+        rows = [
+            {'filepath': '/path/to/file.mp3', 'title': 'Song, "With Quotes"'},
+        ]
+        columns = ['title']
+
+        result = _format_as_csv(rows, columns, 'filepath')
+
+        # CSV should properly quote the value
+        assert '"Song, ""With Quotes"""' in result or 'Song, "With Quotes"' in result
+
+
+class TestWriteOutputNewlines:
+    """Tests for write_output newline handling."""
+
+    def test_write_output_no_double_newlines(self):
+        """Test that written files don't have double newlines from CSV."""
+        # Create CSV-like content with \r\n endings (what csv module produces)
+        content = "header1,header2\r\nvalue1,value2\r\n"
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            write_output(content, temp_path)
+
+            # Read back the file in binary mode to see actual bytes
+            with open(temp_path, 'rb') as f:
+                raw_content = f.read()
+
+            # Should not have \r\r\n (which would be double newline on Windows)
+            assert b'\r\r\n' not in raw_content
+            # Should not have \n\n in the middle of the content
+            # (one \n at the end is OK from write_output)
+            lines = raw_content.strip().split(b'\n')
+            assert len(lines) == 2  # header + 1 data row
+
+        finally:
+            os.unlink(temp_path)
+
+    def test_write_output_creates_file(self):
+        """Test that write_output creates the file."""
+        content = "test content"
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            # Delete the file first to ensure write_output creates it
+            os.unlink(temp_path)
+            assert not os.path.exists(temp_path)
+
+            write_output(content, temp_path)
+
+            assert os.path.exists(temp_path)
+            with open(temp_path, 'r', encoding='utf-8') as f:
+                read_content = f.read()
+            assert 'test content' in read_content
+
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+class TestFormatAnalysisResults:
+    """Tests for analysis results formatting."""
+
+    def test_format_results_csv_basic(self):
+        """Test basic CSV formatting of analysis results."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {'bpm': 128.0},
+                'status': 'success',
+                'error': None
+            }
+        ]
+
+        output = format_analysis_results(results, 'TestAnalyzer', 'csv')
+
+        assert 'TestAnalyzer_bpm' in output
+        assert '128.0' in output
+        assert 'success' in output
+
+    def test_format_results_csv_with_float_bpm(self):
+        """Test that float BPM values are properly formatted in CSV."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {'bpm': 135.9},
+                'status': 'success',
+                'error': None
+            }
+        ]
+
+        output = format_analysis_results(results, 'BPMAnalyzer', 'csv')
+
+        # BPM should be a plain number, not a stringified object
+        assert '135.9' in output
+        assert 'BpmCandidate' not in output
+
+    def test_format_results_table_format(self):
+        """Test table formatting of analysis results."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {'bpm': 120.0},
+                'status': 'success',
+                'error': None
+            }
+        ]
+
+        output = format_analysis_results(results, 'TestAnalyzer', 'table')
+
+        # Table should have headers and separators
+        assert '|' in output
+        assert '-' in output
+
+    def test_format_results_json_format(self):
+        """Test JSON formatting of analysis results."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {'bpm': 120.0},
+                'status': 'success',
+                'error': None
+            }
+        ]
+
+        output = format_analysis_results(results, 'TestAnalyzer', 'json')
+
+        # Should be valid JSON-like structure
+        assert '"filepath"' in output
+        assert '"results"' in output
+
+    def test_format_results_with_error(self):
+        """Test formatting of failed analysis results."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {},
+                'status': 'error',
+                'error': 'Analysis failed'
+            }
+        ]
+
+        output = format_analysis_results(results, 'TestAnalyzer', 'csv')
+
+        assert 'error' in output.lower()
+        assert 'Analysis failed' in output
+
+    def test_format_results_with_skipped(self):
+        """Test formatting of skipped analysis results."""
+        results = [
+            {
+                'filepath': '/path/to/song.mp3',
+                'results': {},
+                'status': 'skipped',
+                'error': 'BPM already set'
+            }
+        ]
+
+        output = format_analysis_results(results, 'TestAnalyzer', 'csv')
+
+        assert 'skipped' in output.lower() or 'Skipped' in output

--- a/tests/workers/test_analyzer_dispatcher_postprocess.py
+++ b/tests/workers/test_analyzer_dispatcher_postprocess.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for analyzer dispatcher result postprocessing.
+
+Tests the _postprocess_result_data function which handles:
+- BPM candidate selection and range adjustment
+- Consistent output between tag writing and report generation
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from util.bpm import BpmCandidate
+from workers.analyzer_dispatcher import _postprocess_result_data
+
+
+class TestPostprocessResultData:
+    """Tests for the _postprocess_result_data function."""
+
+    def test_empty_result_data(self):
+        """Test with empty result data."""
+        result = _postprocess_result_data({}, {})
+        assert result == {}
+
+    def test_none_result_data(self):
+        """Test with None result data."""
+        result = _postprocess_result_data(None, {})
+        assert result == {}
+
+    def test_passthrough_non_bpm_data(self):
+        """Test that non-BPM data is passed through unchanged."""
+        input_data = {'key': 'Am', 'some_value': 42}
+        result = _postprocess_result_data(input_data, {})
+
+        assert result['key'] == 'Am'
+        assert result['some_value'] == 42
+
+    def test_bpm_candidates_converted_to_bpm(self):
+        """Test that bpm_candidates list is converted to single bpm value."""
+        candidates = [BpmCandidate(bpm=128.0, certainty=0.9)]
+        input_data = {'bpm_candidates': candidates}
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            mock_qsettings.value.side_effect = lambda key, default, type: default
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, {})
+
+        assert 'bpm' in result
+        assert result['bpm'] == 128.0
+        assert 'bpm_candidates' not in result
+
+    def test_bpm_candidates_selects_highest_certainty(self):
+        """Test that the candidate with highest certainty is selected."""
+        candidates = [
+            BpmCandidate(bpm=64.0, certainty=0.5),
+            BpmCandidate(bpm=128.0, certainty=0.9),  # Highest certainty
+            BpmCandidate(bpm=256.0, certainty=0.3),
+        ]
+        input_data = {'bpm_candidates': candidates}
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            mock_qsettings.value.side_effect = lambda key, default, type: default
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, {})
+
+        assert result['bpm'] == 128.0
+
+    def test_bpm_range_from_options(self):
+        """Test that BPM range from options is used for adjustment."""
+        # BPM of 64 should be doubled to 128 when min_bpm is 80
+        candidates = [BpmCandidate(bpm=64.0, certainty=0.9)]
+        input_data = {'bpm_candidates': candidates}
+        options = {'bpm_min': 80, 'bpm_max': 200}
+
+        result = _postprocess_result_data(input_data, options)
+
+        # 64 * 2 = 128, which fits in range 80-200
+        assert result['bpm'] == 128.0
+
+    def test_bpm_range_fallback_to_settings(self):
+        """Test that BPM range falls back to QSettings when not in options."""
+        candidates = [BpmCandidate(bpm=64.0, certainty=0.9)]
+        input_data = {'bpm_candidates': candidates}
+        options = {}  # No BPM range in options
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            # Return 80 for min and 200 for max
+            mock_qsettings.value.side_effect = lambda key, default, type: 80 if 'min' in key else 200
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, options)
+
+        # 64 * 2 = 128, which fits in range 80-200
+        assert result['bpm'] == 128.0
+
+    def test_empty_bpm_candidates_list(self):
+        """Test handling of empty bpm_candidates list."""
+        input_data = {'bpm_candidates': []}
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            mock_qsettings.value.side_effect = lambda key, default, type: default
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, {})
+
+        # Should not have 'bpm' key since candidates were empty
+        assert 'bpm' not in result
+        assert 'bpm_candidates' not in result
+
+    def test_preserves_other_data_with_bpm_candidates(self):
+        """Test that other data is preserved when processing BPM candidates."""
+        candidates = [BpmCandidate(bpm=128.0, certainty=0.9)]
+        input_data = {
+            'bpm_candidates': candidates,
+            'key': 'Am',
+            'other_field': 'value'
+        }
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            mock_qsettings.value.side_effect = lambda key, default, type: default
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, {})
+
+        assert result['bpm'] == 128.0
+        assert result['key'] == 'Am'
+        assert result['other_field'] == 'value'
+        assert 'bpm_candidates' not in result
+
+    def test_does_not_modify_original_data(self):
+        """Test that the original data dictionary is not modified."""
+        candidates = [BpmCandidate(bpm=128.0, certainty=0.9)]
+        input_data = {'bpm_candidates': candidates, 'key': 'Am'}
+
+        with patch('workers.analyzer_dispatcher.get_qsettings') as mock_settings:
+            mock_qsettings = MagicMock()
+            mock_qsettings.value.side_effect = lambda key, default, type: default
+            mock_settings.return_value = mock_qsettings
+
+            result = _postprocess_result_data(input_data, {})
+
+        # Original should still have bpm_candidates
+        assert 'bpm_candidates' in input_data
+        assert len(input_data['bpm_candidates']) == 1


### PR DESCRIPTION
### Description

This pull request addresses specific issues with CSV reporting:

- Resolves extra newlines on Windows by specifying `newline=''` when opening files in write mode, ensuring the CSV module properly handles `\r\n` line endings without additional translations.
- Corrects the improper display of `BpmCandidate` objects in CSV outputs by refactoring BPM postprocessing into a reusable function `_postprocess_result_data()` and applying it consistently.
- Adds 22 new tests to improve coverage for CSV formatting and BPM postprocessing. 

### Checklist

- [ ] Tests added for new functionality.
- [ ] Documentation updated (if applicable).
- [ ] Code reviewed for best practices.