### PR TITLE
Add rename-by-metadata feature with format strings and collision handling

### DIFF
--- a/src/util/const.py
+++ b/src/util/const.py
@@ -314,9 +314,10 @@ RENAME_COLLISION_MODE_LABELS = {
 RENAME_PRESETS_DEFAULTS = [
     "%ARTIST% - %TITLE%",
     "%ARTIST% - %TITLE%< (%REMIXER% Remix)>",
-    "<%TRACKNUMBER:00% - >%ARTIST% - %TITLE%",
-    "<<%ALBUMARTIST% - >%ALBUM% - %TRACKNUMBER:00%> %ARTIST% - %TITLE%",
+    "<%TRACKNUMBER:00%. >%ARTIST% - %TITLE%",
+    "<[<%ALBUMARTIST% - ><%ALBUM%>< - %TRACKNUMBER:00%>]> %ARTIST% - %TITLE%< (%REMIXER% Remix)>",
     "<%YEAR% - >%ARTIST% - %ALBUM% - %TRACKNUMBER:00% - %TITLE%",
+    "<%INITIALKEY%,><%BPM:000%,>%ARTIST% - <%ALBUM% - ><%TRACKNUMBER:00% - >%TITLE%< (%REMIXER% Remix)>"
 ]
 
 # Hand-curated sample data used by the rename setup dialog's live "Example:" label.

--- a/src/util/const.py
+++ b/src/util/const.py
@@ -113,6 +113,54 @@ ALL_TAGS = { #display names for each tag
     KEY_YEAR: "Year"
 }
 
+# Section headers used in ALL_FORMATTING_TAGS.
+RENAME_SECTION_TAGS = "Tags"
+RENAME_SECTION_STREAM_INFO = "Stream Info"
+
+# Useful writable tags that aren't in ALL_TAGS but are commonly wanted when
+# composing filenames (remix attributions, label imprints, etc.).
+EXTRA_RENAME_TAGS = {
+    KEY_REMIXER: "Remixer",
+    KEY_LABEL: "Label",
+    KEY_PUBLISHER: "Publisher",
+    KEY_COPYRIGHT: "Copyright",
+    KEY_LYRICIST: "Lyricist",
+    KEY_CONDUCTOR: "Conductor",
+    KEY_ARRANGER: "Arranger",
+    KEY_VERSION: "Version",
+    KEY_DIATONIC_MODE: "Diatonic Mode",
+    KEY_DISC_SUBTITLE: "Disc Subtitle",
+    KEY_MEDIA: "Media",
+    KEY_ORGANIZATION: "Organization",
+    KEY_AUTHOR: "Author",
+}
+
+# Human-readable labels for stream-info keys that are exposed to the rename formatter.
+STREAM_INFO_LABELS = {
+    KEY_BITRATE: "Bitrate",
+    KEY_BITRATE_MODE: "Bitrate Mode",
+    KEY_SAMPLE_RATE: "Sample Rate",
+    KEY_BITS_PER_SAMPLE: "Bits Per Sample",
+    KEY_TOTAL_SAMPLES: "Total Samples",
+    KEY_LENGTH: "Length (seconds)",
+    KEY_CHANNELS: "Channels",
+    KEY_FORMAT: "Format",
+    KEY_ENCODER_INFO: "Encoder Info",
+    KEY_STEREO_MODE: "Stereo Mode",
+}
+
+# Dict-of-arrays: metadata fields usable as tokens in the rename formatter.
+# Top-level keys are section headers. Subarrays list KEY_ constants in display order.
+#   - "Tags": every field from ALL_TAGS plus additional writable tags (remixer,
+#     label, publisher, etc.) that are useful in filenames but aren't in
+#     ALL_TAGS because they aren't default display columns.
+#   - "Stream Info": every STREAM INFO key except the replaygain keys, which
+#     aren't useful in filenames.
+ALL_FORMATTING_TAGS = {
+    RENAME_SECTION_TAGS: list(ALL_TAGS.keys()) + list(EXTRA_RENAME_TAGS.keys()),
+    RENAME_SECTION_STREAM_INFO: list(STREAM_INFO_LABELS.keys()),
+}
+
 
 #### END metadata model keys ####
 
@@ -243,3 +291,75 @@ STARTUP_DIR_MODE_DEFAULT = "last"
 # they are re-exported here so all settings paths are discoverable in one place).
 BPM_RANGE_MIN_KEY = SETTINGS_BPM_RANGE_MIN
 BPM_RANGE_MAX_KEY = SETTINGS_BPM_RANGE_MAX
+
+# Rename-from-metadata settings
+SETTINGS_GROUP_RENAME = "Rename"
+SETTINGS_ARRAY_RENAME_PRESETS = "presets"
+SETTINGS_RENAME_COLLISION_MODE = "Rename/CollisionMode"
+
+# Collision-handling modes for the rename feature.
+RENAME_COLLISION_AUTO_DISAMBIGUATE = "auto_disambiguate"
+RENAME_COLLISION_SKIP = "skip"
+RENAME_COLLISION_OVERWRITE = "overwrite"
+RENAME_COLLISION_MODE_DEFAULT = RENAME_COLLISION_AUTO_DISAMBIGUATE
+
+RENAME_COLLISION_MODE_LABELS = {
+    RENAME_COLLISION_AUTO_DISAMBIGUATE: "Auto-disambiguate (append ' (2)', ' (3)', ...)",
+    RENAME_COLLISION_SKIP: "Skip and report in summary",
+    RENAME_COLLISION_OVERWRITE: "Overwrite existing files",
+}
+
+# Factory-default format strings surfaced through the setup dialog's preset dropdown
+# and through the Preferences > Rename Presets pane's Reset-to-Default button.
+RENAME_PRESETS_DEFAULTS = [
+    "%ARTIST% - %TITLE%",
+    "%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?",
+    "[%TRACKNUMBER:00% - ]?%ARTIST% - %TITLE%",
+    "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER:00%]? %ARTIST% - %TITLE%",
+    "[%YEAR% - ]?%ARTIST% - %ALBUM% - %TRACKNUMBER:00% - %TITLE%",
+]
+
+# Hand-curated sample data used by the rename setup dialog's live "Example:" label.
+# Represents track 7, disc 1 of Dieselboy's "The Dungeonmaster's Guide" (2005):
+# Raiden - Infection (E-Sassin Remix). Keeping this as a developer-editable constant
+# keeps the example self-contained and avoids needing a real file on disk.
+SAMPLE_RENAME_METADATA = {
+    # Tags
+    KEY_ALBUM: "The Dungeonmaster's Guide (Disc 1)",
+    KEY_ALBUM_ARTIST: "Dieselboy",
+    KEY_ARTIST: "Raiden",
+    KEY_BPM: "174",
+    KEY_COMMENT: "",
+    KEY_COMPOSER: "Raiden",
+    KEY_DATE: "2005-06-28",
+    KEY_DISC_NUMBER: "1",
+    KEY_DISC_TOTAL: "2",
+    KEY_ENCODED_BY: "YAAMT",
+    KEY_GENRE: "Drum and Bass",
+    KEY_GROUPING: "",
+    KEY_INITIAL_KEY: "Am",
+    KEY_ISRC: "",
+    KEY_LANGUAGE: "eng",
+    KEY_MOOD: "Dark",
+    KEY_REMIXER: "E-Sassin",
+    KEY_LABEL: "System Recordings",
+    KEY_PUBLISHER: "Human Imprint",
+    KEY_TITLE: "Infection",
+    KEY_TRACK_NUMBER: "7",
+    KEY_TRACK_TOTAL: "9",
+    KEY_YEAR: "2005",
+    # Stream info
+    KEY_BITRATE: 320000,
+    KEY_BITRATE_MODE: "CBR",
+    KEY_SAMPLE_RATE: 44100,
+    KEY_BITS_PER_SAMPLE: 16,
+    KEY_TOTAL_SAMPLES: 15115500,
+    KEY_LENGTH: 342.75,
+    KEY_CHANNELS: 2,
+    KEY_FORMAT: "MP3",
+    KEY_ENCODER_INFO: "LAME 3.100",
+    KEY_STEREO_MODE: "joint stereo",
+}
+
+# Filename extension tacked on to the sample label output.
+SAMPLE_RENAME_EXTENSION = ".mp3"

--- a/src/util/const.py
+++ b/src/util/const.py
@@ -313,10 +313,10 @@ RENAME_COLLISION_MODE_LABELS = {
 # and through the Preferences > Rename Presets pane's Reset-to-Default button.
 RENAME_PRESETS_DEFAULTS = [
     "%ARTIST% - %TITLE%",
-    "%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?",
-    "[%TRACKNUMBER:00% - ]?%ARTIST% - %TITLE%",
-    "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER:00%]? %ARTIST% - %TITLE%",
-    "[%YEAR% - ]?%ARTIST% - %ALBUM% - %TRACKNUMBER:00% - %TITLE%",
+    "%ARTIST% - %TITLE%< (%REMIXER% Remix)>",
+    "<%TRACKNUMBER:00% - >%ARTIST% - %TITLE%",
+    "<<%ALBUMARTIST% - >%ALBUM% - %TRACKNUMBER:00%> %ARTIST% - %TITLE%",
+    "<%YEAR% - >%ARTIST% - %ALBUM% - %TRACKNUMBER:00% - %TITLE%",
 ]
 
 # Hand-curated sample data used by the rename setup dialog's live "Example:" label.

--- a/src/util/rename_formatter.py
+++ b/src/util/rename_formatter.py
@@ -331,8 +331,8 @@ def validate_format_string(format_string: str) -> tuple[bool, str]:
     except FormatParseError as e:
         return False, str(e)
 
-    # Warn on unknown tokens - not fatal (they just render empty), but surfacing
-    # the name helps the user. Walk the AST to collect TAG tokens.
+    # Unknown tokens are treated as a hard validation failure so the dialog
+    # can disable OK and the user knows the format won't do what they think.
     unknown: list[str] = []
     known = _all_known_tokens()
 
@@ -347,5 +347,5 @@ def validate_format_string(format_string: str) -> tuple[bool, str]:
     if unknown:
         unique = ", ".join(sorted(set(unknown)))
         log.debug(f"Unknown rename tokens: {unique}")
-        return True, f"Unknown tokens will render empty: {unique}"
+        return False, f"Unknown token(s): {unique}"
     return True, ""

--- a/src/util/rename_formatter.py
+++ b/src/util/rename_formatter.py
@@ -11,6 +11,11 @@ Format language:
                             where N is the number of '0' characters after the
                             colon. Non-numeric values render unchanged, and
                             values exceeding the pad width render unchanged.
+                            Special case: %INITIALKEY:00% pads the leading
+                            numeric portion of a Camelot-notation key while
+                            preserving the trailing letter (e.g. "7A" -> "07A",
+                            "11B" stays "11B"). No other token has a mixed
+                            numeric/alphabetic pad behavior.
     <section>               Optional section. Renders only if every TAG token
                             directly inside the section resolves to a non-empty
                             value. Sections may be nested; a nested section
@@ -34,11 +39,21 @@ from util.const import (
     ALL_FORMATTING_TAGS,
     ALL_TAGS,
     EXTRA_RENAME_TAGS,
+    KEY_INITIAL_KEY,
     RENAME_SECTION_STREAM_INFO,
     RENAME_SECTION_TAGS,
     STREAM_INFO_LABELS,
 )
 from util.logging import log
+
+
+# Token for KEY_INITIAL_KEY - used by the special Camelot padding rule.
+_INITIAL_KEY_TOKEN = KEY_INITIAL_KEY.upper()
+
+# Matches a run of digits at the very start of a string, optionally preceded
+# by a minus sign. Used for both the default numeric pad and the mixed
+# numeric/alphabetic pad that the Camelot special case relies on.
+_LEADING_NUMERIC_RE = re.compile(r"^(-?)(\d+)(.*)$", re.DOTALL)
 
 
 # Characters that are invalid in filenames on at least one supported OS. We
@@ -215,19 +230,43 @@ def _parse_section(
 # ---------------------------------------------------------------------------
 
 
+def _pad_fully_numeric(value: str, pad: int) -> str:
+    """Pad value if it is entirely numeric; return value unchanged otherwise."""
+    stripped = value.strip()
+    if stripped and stripped.lstrip("-").isdigit():
+        n = int(stripped)
+        formatted = f"{abs(n):0{pad}d}"
+        if n < 0:
+            formatted = f"-{formatted}"
+        return formatted
+    return value
+
+
+def _pad_leading_numeric(value: str, pad: int) -> str:
+    """
+    Pad the leading numeric portion of value, preserving any trailing content.
+
+    Used exclusively for Camelot-notation keys (e.g. "7A" -> "07A"). If the
+    value has no leading digits the input is returned unchanged.
+    """
+    m = _LEADING_NUMERIC_RE.match(value.strip())
+    if m is None:
+        return value
+    sign, digits, rest = m.groups()
+    n = int(digits)
+    return f"{sign}{n:0{pad}d}{rest}"
+
+
 def _render_tag(node: dict[str, Any], token_map: dict[str, str]) -> str:
     """Render a single TAG node, applying numeric padding if requested."""
     value = token_map.get(node["token"], "")
     pad = node["pad"]
-    if pad and value:
-        stripped = value.strip()
-        if stripped and stripped.lstrip("-").isdigit():
-            n = int(stripped)
-            formatted = f"{abs(n):0{pad}d}"
-            if n < 0:
-                formatted = f"-{formatted}"
-            return formatted
-    return value
+    if not pad or not value:
+        return value
+    if node["token"] == _INITIAL_KEY_TOKEN:
+        # Camelot / mixed notation: pad leading digits, keep letter suffix.
+        return _pad_leading_numeric(value, pad)
+    return _pad_fully_numeric(value, pad)
 
 
 def _render_nodes(

--- a/src/util/rename_formatter.py
+++ b/src/util/rename_formatter.py
@@ -1,0 +1,351 @@
+"""
+Format-string parser for the "Rename files based on metadata" feature.
+
+Format language:
+
+    %TOKEN%                 Substitute the tag value associated with TOKEN.
+                            Matching is case-insensitive against the uppercase
+                            form of each KEY_ constant's string value (see
+                            util.const.ALL_FORMATTING_TAGS).
+    %TOKEN:000%             Pad a numeric value to N digits with leading zeros,
+                            where N is the number of '0' characters after the
+                            colon. Non-numeric values render unchanged, and
+                            values exceeding the pad width render unchanged.
+    [section]?              Optional section. Renders only if every TAG token
+                            directly inside the section resolves to a non-empty
+                            value. Sections may be nested; a nested section
+                            that collapses to empty does NOT poison its parent
+                            section's presence check.
+
+The sanitizer strips path separators, Windows-reserved chars, and control
+characters so the rendered filename is safe to apply with os.rename.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.media_file import MediaFile
+
+from util.const import (
+    ALL_FORMATTING_TAGS,
+    ALL_TAGS,
+    EXTRA_RENAME_TAGS,
+    RENAME_SECTION_STREAM_INFO,
+    RENAME_SECTION_TAGS,
+    STREAM_INFO_LABELS,
+)
+from util.logging import log
+
+
+# Characters that are invalid in filenames on at least one supported OS. We
+# strip them unconditionally to keep output portable.
+FILENAME_RESERVED_CHARS = r'/\:*?"<>|'
+FILENAME_REPLACEMENT_CHAR = "_"
+
+# AST node kinds for the parsed format string.
+_NODE_LITERAL = "literal"
+_NODE_TAG = "tag"
+_NODE_OPTIONAL = "optional"
+
+
+def _token_name_for_key(key: str) -> str:
+    """Uppercase-normalized token name used in format strings for a KEY_ constant."""
+    return key.upper()
+
+
+def list_tokens_by_section() -> dict[str, list[tuple[str, str]]]:
+    """
+    Return tokens grouped by display section.
+
+    Each entry is (token_text, description). Used by the token-reference dialog.
+    """
+    out: dict[str, list[tuple[str, str]]] = {}
+    for section, keys in ALL_FORMATTING_TAGS.items():
+        rows: list[tuple[str, str]] = []
+        for key in keys:
+            if section == RENAME_SECTION_TAGS:
+                label = ALL_TAGS.get(key) or EXTRA_RENAME_TAGS.get(key, key)
+            elif section == RENAME_SECTION_STREAM_INFO:
+                label = STREAM_INFO_LABELS.get(key, key)
+            else:
+                label = key
+            rows.append((f"%{_token_name_for_key(key)}%", label))
+        out[section] = rows
+    return out
+
+
+def _all_known_tokens() -> set[str]:
+    """Set of upper-cased token names recognized by the formatter."""
+    tokens: set[str] = set()
+    for keys in ALL_FORMATTING_TAGS.values():
+        for key in keys:
+            tokens.add(_token_name_for_key(key))
+    return tokens
+
+
+def _coerce_value(value: Any) -> str:
+    """Convert a tag or stream-info value to a string suitable for a filename."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        # Bool is a subclass of int in Python; handle before numerics.
+        return "1" if value else "0"
+    if isinstance(value, float):
+        # Drop trailing zeros and decimal point when whole. Round length values.
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:g}"
+    if isinstance(value, (int,)):
+        return str(value)
+    return str(value)
+
+
+def build_token_map(media_file: "MediaFile") -> dict[str, str]:
+    """
+    Build an uppercase-keyed token map for a MediaFile.
+
+    Every token listed in ALL_FORMATTING_TAGS is populated (empty string if
+    absent on the file) so that optional-section collapse logic works uniformly.
+    """
+    out: dict[str, str] = {}
+    for key in ALL_FORMATTING_TAGS.get(RENAME_SECTION_TAGS, []):
+        value = media_file.get_tag_simple(key)
+        out[_token_name_for_key(key)] = _coerce_value(value)
+    for key in ALL_FORMATTING_TAGS.get(RENAME_SECTION_STREAM_INFO, []):
+        value = media_file.get_stream_info_value(key)
+        out[_token_name_for_key(key)] = _coerce_value(value)
+    return out
+
+
+def build_token_map_from_dict(raw: dict[str, Any]) -> dict[str, str]:
+    """Variant of build_token_map that reads a plain dict (used by sample data)."""
+    out: dict[str, str] = {}
+    for keys in ALL_FORMATTING_TAGS.values():
+        for key in keys:
+            out[_token_name_for_key(key)] = _coerce_value(raw.get(key))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+# Matches %TOKEN% or %TOKEN:0000%. Token chars: A-Z, 0-9, underscore.
+_TAG_RE = re.compile(r"%([A-Za-z_][A-Za-z0-9_]*)(?::(0+))?%")
+
+
+class FormatParseError(ValueError):
+    """Raised when the format string is malformed."""
+
+
+def _parse(format_string: str) -> list[dict[str, Any]]:
+    """Parse the format string into a flat list of AST nodes."""
+    nodes, pos = _parse_section(format_string, 0, top_level=True)
+    if pos != len(format_string):
+        raise FormatParseError(
+            f"Unexpected trailing content at position {pos}: {format_string[pos:]!r}"
+        )
+    return nodes
+
+
+def _parse_section(
+    s: str, pos: int, top_level: bool
+) -> tuple[list[dict[str, Any]], int]:
+    """Parse until we hit a ']?' terminator (if not top-level) or end-of-string."""
+    nodes: list[dict[str, Any]] = []
+    buf: list[str] = []
+
+    def flush_literal() -> None:
+        if buf:
+            nodes.append({"kind": _NODE_LITERAL, "text": "".join(buf)})
+            buf.clear()
+
+    while pos < len(s):
+        ch = s[pos]
+
+        if ch == "[":
+            # Start a nested optional section.
+            flush_literal()
+            inner, new_pos = _parse_section(s, pos + 1, top_level=False)
+            nodes.append({"kind": _NODE_OPTIONAL, "children": inner})
+            pos = new_pos
+            continue
+
+        if ch == "]":
+            # Must be followed by '?' to terminate an optional section.
+            if not top_level and pos + 1 < len(s) and s[pos + 1] == "?":
+                flush_literal()
+                return nodes, pos + 2
+            # Literal ']' (no terminator).
+            buf.append(ch)
+            pos += 1
+            continue
+
+        if ch == "%":
+            m = _TAG_RE.match(s, pos)
+            if m:
+                flush_literal()
+                token = m.group(1).upper()
+                pad_width = len(m.group(2)) if m.group(2) else 0
+                nodes.append(
+                    {"kind": _NODE_TAG, "token": token, "pad": pad_width}
+                )
+                pos = m.end()
+                continue
+            # Literal '%' not part of a token.
+            buf.append(ch)
+            pos += 1
+            continue
+
+        buf.append(ch)
+        pos += 1
+
+    if not top_level:
+        raise FormatParseError("Unterminated '[' - missing ']?'")
+
+    flush_literal()
+    return nodes, pos
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_tag(node: dict[str, Any], token_map: dict[str, str]) -> str:
+    """Render a single TAG node, applying numeric padding if requested."""
+    value = token_map.get(node["token"], "")
+    pad = node["pad"]
+    if pad and value:
+        stripped = value.strip()
+        if stripped and stripped.lstrip("-").isdigit():
+            n = int(stripped)
+            formatted = f"{abs(n):0{pad}d}"
+            if n < 0:
+                formatted = f"-{formatted}"
+            return formatted
+    return value
+
+
+def _render_nodes(
+    nodes: list[dict[str, Any]], token_map: dict[str, str]
+) -> tuple[str, bool]:
+    """
+    Render a list of nodes.
+
+    Returns (text, all_direct_tags_non_empty). Optional children contribute
+    their rendered text when non-empty but are NOT considered for the parent's
+    direct-tag presence check.
+    """
+    parts: list[str] = []
+    all_direct_present = True
+    has_direct_tag = False
+
+    for node in nodes:
+        kind = node["kind"]
+        if kind == _NODE_LITERAL:
+            parts.append(node["text"])
+        elif kind == _NODE_TAG:
+            has_direct_tag = True
+            rendered = _render_tag(node, token_map)
+            if not rendered:
+                all_direct_present = False
+            parts.append(rendered)
+        elif kind == _NODE_OPTIONAL:
+            child_text, child_ok = _render_nodes(node["children"], token_map)
+            if child_ok:
+                parts.append(child_text)
+            # Collapsed nested sections don't affect parent presence.
+
+    # A section with no direct tags at all is considered "present" (e.g. a
+    # literal-only optional section renders unconditionally - odd but harmless).
+    if not has_direct_tag:
+        all_direct_present = True
+
+    return "".join(parts), all_direct_present
+
+
+def format_filename(format_string: str, token_map: dict[str, str]) -> str:
+    """
+    Render a format string against a token map.
+
+    Raises FormatParseError if the format string is malformed.
+    """
+    nodes = _parse(format_string)
+    text, _ = _render_nodes(nodes, token_map)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Filename sanitization
+# ---------------------------------------------------------------------------
+
+
+def sanitize_filename(name: str) -> str:
+    """
+    Strip path separators, reserved chars, and control chars from a filename.
+
+    Also collapses runs of whitespace and trims leading/trailing whitespace,
+    dots, and underscores. Returns '' if nothing usable remains - callers
+    should treat empty output as an error.
+    """
+    # Replace reserved/separator chars with the replacement char. Control
+    # whitespace (tab/newline) gets normalized to a space so the subsequent
+    # \s+ collapse merges it with surrounding whitespace instead of leaving
+    # behind stranded underscores.
+    cleaned_chars: list[str] = []
+    for ch in name:
+        if ch in FILENAME_RESERVED_CHARS:
+            cleaned_chars.append(FILENAME_REPLACEMENT_CHAR)
+        elif ord(ch) < 0x20:
+            cleaned_chars.append(" " if ch.isspace() else FILENAME_REPLACEMENT_CHAR)
+        else:
+            cleaned_chars.append(ch)
+    cleaned = "".join(cleaned_chars)
+
+    # Collapse runs of whitespace.
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+    # Strip leading/trailing dots to avoid creating hidden files or Windows
+    # trailing-dot issues, and trailing replacement chars.
+    cleaned = cleaned.strip(". ")
+    cleaned = cleaned.strip(FILENAME_REPLACEMENT_CHAR + " ")
+
+    # Guard against names that are solely '.' or ''.
+    if cleaned in ("", ".", ".."):
+        return ""
+    return cleaned
+
+
+def validate_format_string(format_string: str) -> tuple[bool, str]:
+    """
+    Quick validation helper for UI use.
+
+    Returns (is_valid, error_message).
+    """
+    try:
+        nodes = _parse(format_string)
+    except FormatParseError as e:
+        return False, str(e)
+
+    # Warn on unknown tokens - not fatal (they just render empty), but surfacing
+    # the name helps the user. Walk the AST to collect TAG tokens.
+    unknown: list[str] = []
+    known = _all_known_tokens()
+
+    def _walk(nodes_: list[dict[str, Any]]) -> None:
+        for n in nodes_:
+            if n["kind"] == _NODE_TAG and n["token"] not in known:
+                unknown.append(n["token"])
+            elif n["kind"] == _NODE_OPTIONAL:
+                _walk(n["children"])
+
+    _walk(nodes)
+    if unknown:
+        unique = ", ".join(sorted(set(unknown)))
+        log.debug(f"Unknown rename tokens: {unique}")
+        return True, f"Unknown tokens will render empty: {unique}"
+    return True, ""

--- a/src/util/rename_formatter.py
+++ b/src/util/rename_formatter.py
@@ -11,11 +11,12 @@ Format language:
                             where N is the number of '0' characters after the
                             colon. Non-numeric values render unchanged, and
                             values exceeding the pad width render unchanged.
-    [section]?              Optional section. Renders only if every TAG token
+    <section>               Optional section. Renders only if every TAG token
                             directly inside the section resolves to a non-empty
                             value. Sections may be nested; a nested section
                             that collapses to empty does NOT poison its parent
-                            section's presence check.
+                            section's presence check. '[' and ']' are always
+                            literal characters.
 
 The sanitizer strips path separators, Windows-reserved chars, and control
 characters so the rendered filename is safe to apply with os.rename.
@@ -154,7 +155,7 @@ def _parse(format_string: str) -> list[dict[str, Any]]:
 def _parse_section(
     s: str, pos: int, top_level: bool
 ) -> tuple[list[dict[str, Any]], int]:
-    """Parse until we hit a ']?' terminator (if not top-level) or end-of-string."""
+    """Parse until we hit a '>' terminator (if not top-level) or end-of-string."""
     nodes: list[dict[str, Any]] = []
     buf: list[str] = []
 
@@ -166,7 +167,7 @@ def _parse_section(
     while pos < len(s):
         ch = s[pos]
 
-        if ch == "[":
+        if ch == "<":
             # Start a nested optional section.
             flush_literal()
             inner, new_pos = _parse_section(s, pos + 1, top_level=False)
@@ -174,12 +175,11 @@ def _parse_section(
             pos = new_pos
             continue
 
-        if ch == "]":
-            # Must be followed by '?' to terminate an optional section.
-            if not top_level and pos + 1 < len(s) and s[pos + 1] == "?":
+        if ch == ">":
+            if not top_level:
                 flush_literal()
-                return nodes, pos + 2
-            # Literal ']' (no terminator).
+                return nodes, pos + 1
+            # Literal '>' at top level (no matching opener).
             buf.append(ch)
             pos += 1
             continue
@@ -204,7 +204,7 @@ def _parse_section(
         pos += 1
 
     if not top_level:
-        raise FormatParseError("Unterminated '[' - missing ']?'")
+        raise FormatParseError("Unterminated '<' - missing '>'")
 
     flush_literal()
     return nodes, pos

--- a/src/util/rename_formatter.py
+++ b/src/util/rename_formatter.py
@@ -11,11 +11,20 @@ Format language:
                             where N is the number of '0' characters after the
                             colon. Non-numeric values render unchanged, and
                             values exceeding the pad width render unchanged.
+                            If the actual value is a decimal (e.g. "174.5"),
+                            the fractional portion is always preserved, so
+                            "174.5" with :000 renders as "174.5" (not "174").
                             Special case: %INITIALKEY:00% pads the leading
                             numeric portion of a Camelot-notation key while
                             preserving the trailing letter (e.g. "7A" -> "07A",
                             "11B" stays "11B"). No other token has a mixed
                             numeric/alphabetic pad behavior.
+    %TOKEN:000.0%           Pad the integer portion like :000, and force at
+                            least one decimal place. The decimal-pad count is
+                            a minimum: if the actual value has more decimal
+                            digits, they are preserved verbatim. So "174" with
+                            :000.0 renders as "174.0", "90" becomes "090.0",
+                            "174.55" with :000.0 stays "174.55".
     <section>               Optional section. Renders only if every TAG token
                             directly inside the section resolves to a non-empty
                             value. Sections may be nested; a nested section
@@ -149,8 +158,11 @@ def build_token_map_from_dict(raw: dict[str, Any]) -> dict[str, str]:
 # Parser
 # ---------------------------------------------------------------------------
 
-# Matches %TOKEN% or %TOKEN:0000%. Token chars: A-Z, 0-9, underscore.
-_TAG_RE = re.compile(r"%([A-Za-z_][A-Za-z0-9_]*)(?::(0+))?%")
+# Matches %TOKEN%, %TOKEN:0000%, or %TOKEN:0000.000%. Token chars: A-Z, 0-9,
+# underscore. The optional pad spec is one run of zeros for integer padding,
+# then optionally a '.' followed by another run of zeros for minimum-decimal
+# padding.
+_TAG_RE = re.compile(r"%([A-Za-z_][A-Za-z0-9_]*)(?::(0+)(?:\.(0+))?)?%")
 
 
 class FormatParseError(ValueError):
@@ -205,8 +217,14 @@ def _parse_section(
                 flush_literal()
                 token = m.group(1).upper()
                 pad_width = len(m.group(2)) if m.group(2) else 0
+                decimal_pad = len(m.group(3)) if m.group(3) else 0
                 nodes.append(
-                    {"kind": _NODE_TAG, "token": token, "pad": pad_width}
+                    {
+                        "kind": _NODE_TAG,
+                        "token": token,
+                        "pad": pad_width,
+                        "decimal_pad": decimal_pad,
+                    }
                 )
                 pos = m.end()
                 continue
@@ -230,16 +248,58 @@ def _parse_section(
 # ---------------------------------------------------------------------------
 
 
-def _pad_fully_numeric(value: str, pad: int) -> str:
-    """Pad value if it is entirely numeric; return value unchanged otherwise."""
+def _split_numeric(value: str) -> tuple[str, str, str] | None:
+    """
+    Split a fully-numeric value into (sign, int_part, frac_part).
+
+    Returns None if value isn't a plain signed integer or decimal. Accepts
+    "123", "-7", "174.5", "-0.25". Rejects leading-dot ".5", trailing-dot
+    "5.", or anything with non-numeric tail.
+    """
     stripped = value.strip()
-    if stripped and stripped.lstrip("-").isdigit():
-        n = int(stripped)
-        formatted = f"{abs(n):0{pad}d}"
-        if n < 0:
-            formatted = f"-{formatted}"
-        return formatted
-    return value
+    if not stripped:
+        return None
+    sign = ""
+    rest = stripped
+    if rest.startswith(("-", "+")):
+        sign = "-" if rest[0] == "-" else ""
+        rest = rest[1:]
+    if "." in rest:
+        int_part, _, frac_part = rest.partition(".")
+        if not int_part or not frac_part:
+            return None
+        if not int_part.isdigit() or not frac_part.isdigit():
+            return None
+    else:
+        if not rest.isdigit():
+            return None
+        int_part = rest
+        frac_part = ""
+    return sign, int_part, frac_part
+
+
+def _pad_fully_numeric(value: str, pad: int, decimal_pad: int) -> str:
+    """
+    Pad an integer-or-decimal value.
+
+    - Leading zeros pad the integer portion to `pad` digits.
+    - Decimal portion is preserved verbatim when present.
+    - When `decimal_pad` > 0, the output is guaranteed to have at least
+      `decimal_pad` fractional digits (padded with trailing zeros). Actual
+      decimal digits, if any, are always preserved regardless of
+      `decimal_pad`; the spec is a minimum, never a truncation.
+    """
+    parsed = _split_numeric(value)
+    if parsed is None:
+        return value
+    sign, int_part, frac_part = parsed
+    int_n = int(int_part)
+    padded_int = f"{int_n:0{pad}d}"
+    target_frac_len = max(decimal_pad, len(frac_part))
+    if target_frac_len > 0:
+        frac_padded = frac_part.ljust(target_frac_len, "0")
+        return f"{sign}{padded_int}.{frac_padded}"
+    return f"{sign}{padded_int}"
 
 
 def _pad_leading_numeric(value: str, pad: int) -> str:
@@ -247,7 +307,8 @@ def _pad_leading_numeric(value: str, pad: int) -> str:
     Pad the leading numeric portion of value, preserving any trailing content.
 
     Used exclusively for Camelot-notation keys (e.g. "7A" -> "07A"). If the
-    value has no leading digits the input is returned unchanged.
+    value has no leading digits the input is returned unchanged. Decimal-pad
+    spec is ignored here since Camelot notation isn't a decimal number.
     """
     m = _LEADING_NUMERIC_RE.match(value.strip())
     if m is None:
@@ -261,12 +322,13 @@ def _render_tag(node: dict[str, Any], token_map: dict[str, str]) -> str:
     """Render a single TAG node, applying numeric padding if requested."""
     value = token_map.get(node["token"], "")
     pad = node["pad"]
-    if not pad or not value:
+    decimal_pad = node.get("decimal_pad", 0)
+    if (not pad and not decimal_pad) or not value:
         return value
     if node["token"] == _INITIAL_KEY_TOKEN:
         # Camelot / mixed notation: pad leading digits, keep letter suffix.
         return _pad_leading_numeric(value, pad)
-    return _pad_fully_numeric(value, pad)
+    return _pad_fully_numeric(value, pad, decimal_pad)
 
 
 def _render_nodes(

--- a/src/windows/analyzer/progress_dialog.py
+++ b/src/windows/analyzer/progress_dialog.py
@@ -30,15 +30,32 @@ class AnalyzerProgressDialog(QDialog):
     - Cancel button with option to keep/discard partial results
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        dispatcher: Any | None = None,
+        title: str = "Analyzing Files",
+        cancel_button_text: str = "Cancel Analysis",
+        supports_discard: bool = True,
+        cancel_prompt_title: str = "Cancel Analysis",
+        cancel_prompt_body: str = (
+            "Do you want to keep the results from files already analyzed?"
+        ),
+    ) -> None:
         """
         Initialize the progress dialog.
 
         Args:
             parent: Parent widget
+            dispatcher: Any object exposing task_started/task_completed/
+                progress_updated/analysis_completed/active_tasks_updated
+                signals plus cancel_all(). Defaults to AnalyzerDispatcher()
+                for backward compatibility with existing analyzer call sites.
+            title: Window title (e.g. "Analyzing Files" or "Renaming Files").
+            cancel_button_text: Label for the cancel button.
         """
         super().__init__(parent)
-        self.setWindowTitle("Analyzing Files")
+        self.setWindowTitle(title)
         self.setMinimumWidth(500)
         self.setMinimumHeight(200)
         self.setModal(True)
@@ -46,7 +63,11 @@ class AnalyzerProgressDialog(QDialog):
             self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint
         )
 
-        self.dispatcher = AnalyzerDispatcher()
+        self.dispatcher = dispatcher if dispatcher is not None else AnalyzerDispatcher()
+        self._cancel_button_text = cancel_button_text
+        self._supports_discard = supports_discard
+        self._cancel_prompt_title = cancel_prompt_title
+        self._cancel_prompt_body = cancel_prompt_body
         self._is_cancelled = False
         self._completed_count = 0
         self._total_count = 0
@@ -101,7 +122,7 @@ class AnalyzerProgressDialog(QDialog):
         layout.addSpacing(10)
 
         # Cancel button (fixed at bottom)
-        self.cancel_button = QPushButton("Cancel Analysis")
+        self.cancel_button = QPushButton(self._cancel_button_text)
         self.cancel_button.clicked.connect(self._on_cancel_clicked)
         layout.addWidget(self.cancel_button)
 
@@ -273,31 +294,49 @@ class AnalyzerProgressDialog(QDialog):
 
     def _on_cancel_clicked(self) -> None:
         """Handle cancel button click."""
-        # Prompt user about keeping partial results
-        reply = QMessageBox.question(
-            self,
-            "Cancel Analysis",
-            "Do you want to keep the results from files already analyzed?\n\n"
-            f"Progress: {self._completed_count}/{self._total_count} files completed",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Yes
+        progress_line = (
+            f"\n\nProgress: {self._completed_count}/{self._total_count} files completed"
         )
 
-        if reply == QMessageBox.StandardButton.Cancel:
-            # User cancelled the cancellation
-            return
-        elif reply == QMessageBox.StandardButton.Yes:
-            # Keep partial results
-            log.info("User cancelled analysis, keeping partial results")
-            self.dispatcher.cancel_all()
-            self._is_cancelled = True
-            self.accept()
-        else:  # No
-            # Discard all results
-            log.info("User cancelled analysis, discarding all results")
-            self.dispatcher.cancel_all()
-            self._is_cancelled = True
-            self.reject()
+        if self._supports_discard:
+            # Analyzer flow: Yes = keep partial results, No = discard.
+            reply = QMessageBox.question(
+                self,
+                self._cancel_prompt_title,
+                self._cancel_prompt_body + progress_line,
+                QMessageBox.StandardButton.Yes
+                | QMessageBox.StandardButton.No
+                | QMessageBox.StandardButton.Cancel,
+                QMessageBox.StandardButton.Yes,
+            )
+
+            if reply == QMessageBox.StandardButton.Cancel:
+                return
+            elif reply == QMessageBox.StandardButton.Yes:
+                log.info("User cancelled operation, keeping partial results")
+                self.dispatcher.cancel_all()
+                self._is_cancelled = True
+                self.accept()
+            else:
+                log.info("User cancelled operation, discarding all results")
+                self.dispatcher.cancel_all()
+                self._is_cancelled = True
+                self.reject()
+        else:
+            # Rename flow: already-applied filesystem operations can't be
+            # discarded. Just confirm stop-the-queue with a plain Yes/No.
+            reply = QMessageBox.question(
+                self,
+                self._cancel_prompt_title,
+                self._cancel_prompt_body + progress_line,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if reply == QMessageBox.StandardButton.Yes:
+                log.info("User cancelled remaining operations")
+                self.dispatcher.cancel_all()
+                self._is_cancelled = True
+                self.accept()
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """Handle dialog close event."""

--- a/src/windows/analyzer/summary_dialog.py
+++ b/src/windows/analyzer/summary_dialog.py
@@ -30,21 +30,36 @@ class AnalyzerSummaryDialog(QDialog):
     # Signal emitted when user wants to select failed/skipped files
     select_files_requested = Signal(list)  # List of file paths
 
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent=None,
+        summary: dict | None = None,
+        title: str = "Analysis Complete",
+        success_verb: str = "analyzed",
+    ):
         """
         Initialize the summary dialog.
 
         Args:
             parent: Parent widget
+            summary: Pre-built summary dict matching
+                AnalyzerDispatcher.get_summary()'s shape. If None, falls back
+                to the analyzer singleton for backward compatibility.
+            title: Window title (e.g. "Analysis Complete", "Rename Complete").
+            success_verb: Past-tense verb used in the header label
+                (e.g. "analyzed" or "renamed").
         """
         super().__init__(parent)
-        self.setWindowTitle("Analysis Complete")
+        self.setWindowTitle(title)
         self.setMinimumWidth(600)
         self.setMinimumHeight(400)
         self.setModal(True)
 
-        self.dispatcher = AnalyzerDispatcher()
-        self.summary = self.dispatcher.get_summary()
+        if summary is None:
+            # Legacy analyzer call site - fetch summary from the singleton.
+            summary = AnalyzerDispatcher().get_summary()
+        self.summary = summary
+        self._success_verb = success_verb
 
         self._setup_ui()
 
@@ -58,7 +73,7 @@ class AnalyzerSummaryDialog(QDialog):
         failed_count = len(self.summary['failed'])
         skipped_count = len(self.summary['skipped'])
 
-        summary_text = f"Successfully analyzed: {successful} / {total} files"
+        summary_text = f"Successfully {self._success_verb}: {successful} / {total} files"
         summary_label = QLabel(summary_text)
         summary_label.setStyleSheet("QLabel { font-size: 14pt; font-weight: bold; }")
         layout.addWidget(summary_label)
@@ -107,7 +122,7 @@ class AnalyzerSummaryDialog(QDialog):
 
         # If all successful, show a success message
         if failed_count == 0 and skipped_count == 0 and total > 0:
-            success_label = QLabel("All files analyzed successfully!")
+            success_label = QLabel(f"All files {self._success_verb} successfully!")
             success_label.setStyleSheet("QLabel { color: green; font-weight: bold; }")
             success_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(success_label)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 from PySide6.QtWidgets import (
     QMainWindow, QToolBar, QStatusBar, QSplitter, QLabel, QProgressBar,
     QPushButton, QStyle, QTreeView, QFileSystemModel, QMenu, QMessageBox,
@@ -29,6 +30,8 @@ from util.const import (
     SETTINGS_GROUP_FAVORITES, SETTINGS_ARRAY_FAVORITES_LOCATIONS,
     SETTINGS_GROUP_FILE_LIST, SETTINGS_ARRAY_FILE_LIST_COLUMNS,
 )
+from windows.rename.setup_dialog import RenameSetupDialog
+from workers.rename_dispatcher import RenameDispatcher
 from util.debug import is_debug_mode
 from util.file_browser import open_in_file_browser
 from util.logging import log
@@ -522,6 +525,10 @@ class MainWindow(QMainWindow):
         analyze_menu = self._build_analyze_menu()
         menu.addMenu(analyze_menu)
 
+        # Add Metadata submenu
+        metadata_menu = self._build_metadata_menu()
+        menu.addMenu(metadata_menu)
+
         menu.exec_(self.files_view.mapToGlobal(pos))
 
     def toggle_column(self, index, checked):
@@ -596,6 +603,15 @@ class MainWindow(QMainWindow):
         self.action_properties.setEnabled(False)
         self.action_properties.triggered.connect(self.open_properties_window)
 
+        # Metadata submenu actions
+        self.action_rename_from_metadata = QAction(
+            "Rename files based on metadata...", self
+        )
+        self.action_rename_from_metadata.setEnabled(False)
+        self.action_rename_from_metadata.triggered.connect(
+            self._on_rename_files_requested
+        )
+
         # Playback actions
         self.action_play_file = QAction("Play this file", self)
         self.action_play_file.setEnabled(False)
@@ -623,6 +639,10 @@ class MainWindow(QMainWindow):
         # Add Analyze submenu
         analyze_menu = self._build_analyze_menu()
         file_menu.addMenu(analyze_menu)
+
+        # Add Metadata submenu
+        metadata_menu = self._build_metadata_menu()
+        file_menu.addMenu(metadata_menu)
         file_menu.addSeparator()
 
         file_menu.addAction(self.action_properties)
@@ -875,6 +895,15 @@ class MainWindow(QMainWindow):
         about_window = windows.AboutWindow(self)
         about_window.exec()
 
+    def _build_metadata_menu(self) -> QMenu:
+        """
+        Build the Metadata submenu (used by both the File menu and the
+        right-click context menu). Houses bulk-metadata actions like rename.
+        """
+        metadata_menu = QMenu("&Metadata", self)
+        metadata_menu.addAction(self.action_rename_from_metadata)
+        return metadata_menu
+
     def _build_analyze_menu(self):
         """
         Build the Analyze submenu with categories.
@@ -950,8 +979,25 @@ class MainWindow(QMainWindow):
         dispatcher.reset()  # Clear any previous state
         dispatcher.enqueue(analyzer_class, media_files, options)
 
+        # Refresh the file list as soon as the dispatcher finishes, before the
+        # summary dialog shows. Using a single-shot connection keeps later
+        # analyzer runs from stacking refreshes on the singleton dispatcher.
+        refresh_conn: list[Any] = []
+
+        def _refresh_on_complete():
+            self._refresh_after_batch(media_files)
+            conn = refresh_conn[0] if refresh_conn else None
+            if conn is not None:
+                try:
+                    dispatcher.analysis_completed.disconnect(conn)
+                except (RuntimeError, TypeError):
+                    pass
+
+        refresh_conn.append(_refresh_on_complete)
+        dispatcher.analysis_completed.connect(_refresh_on_complete)
+
         # Show progress dialog
-        progress_dialog = AnalyzerProgressDialog(self)
+        progress_dialog = AnalyzerProgressDialog(self, dispatcher=dispatcher)
 
         # Start analysis
         dispatcher.start()
@@ -961,22 +1007,126 @@ class MainWindow(QMainWindow):
 
         # Show summary dialog after completion
         if result == QDialog.DialogCode.Accepted:
-            summary_dialog = AnalyzerSummaryDialog(self)
+            summary_dialog = AnalyzerSummaryDialog(
+                self, summary=dispatcher.get_summary()
+            )
             summary_dialog.select_files_requested.connect(self._on_select_analyzer_files)
             summary_dialog.exec()
 
-            # Refresh the file list to show updated metadata
-            # Get the file IDs that were analyzed
-            file_ids = [mf.file_id for mf in media_files]
+    def _refresh_after_batch(self, media_files: list) -> None:
+        """
+        Refresh the file list after an analyzer or rename batch completes.
 
-            # Clear any staged changes for these files (analyzer results are authoritative)
-            self.edit_manager.clear_staged_changes_for_files(file_ids)
+        For analyzer runs (file paths unchanged), we refresh in place via
+        MetadataTableModel.refresh_files(). For rename runs (some MediaFile's
+        on-disk path no longer matches the listed path), we fall back to a
+        full directory rescan because the model's rows are keyed by path.
+        """
+        try:
+            paths_changed = any(
+                not os.path.exists(mf.file_path)
+                for mf in media_files
+            )
+        except Exception:
+            paths_changed = False
 
-            # Force-replace MediaFile instances to ensure fresh data is used
-            self.edit_manager.register_media_files(media_files, force_replace=True)
+        if paths_changed and self._current_path:
+            # Full rescan: file paths have changed (e.g. after rename).
+            log.info("Batch changed file paths; triggering full directory rescan")
+            self.set_path(self._current_path)
+            return
 
-            # Refresh the display
-            self.file_model.refresh_files(file_ids, self.edit_manager)
+        file_ids = [mf.file_id for mf in media_files]
+        # Clear any staged changes for these files; results are authoritative.
+        self.edit_manager.clear_staged_changes_for_files(file_ids)
+        # Force-replace MediaFile instances so the display picks up new data.
+        self.edit_manager.register_media_files(media_files, force_replace=True)
+        self.file_model.refresh_files(file_ids, self.edit_manager)
+
+    def _on_rename_files_requested(self) -> None:
+        """
+        Entry point for the "Rename files based on metadata..." action.
+
+        Collects the currently selected media files, shows the setup dialog,
+        then drives a RenameDispatcher through the shared progress/summary
+        dialogs and refreshes the file list.
+        """
+        selected_indexes = self.files_view.selectionModel().selectedRows()
+        if not selected_indexes:
+            log.debug("No files selected for rename")
+            return
+
+        media_files = []
+        for index in selected_indexes:
+            source_index = self.proxy_model.mapToSource(index)
+            row_data = self.file_model.get_data_for_row(row=source_index.row())
+            file_path = row_data.get(KEY_FILE_PATH)
+            if file_path and row_data.get(KEY_IS_MEDIA):
+                media_files.append(MediaFile(file_path, enable_write=True))
+
+        if not media_files:
+            log.debug("No valid media files selected for rename")
+            return
+
+        setup_dialog = RenameSetupDialog(media_files, self)
+        if setup_dialog.exec() != QDialog.DialogCode.Accepted:
+            log.debug("Rename cancelled by user in setup dialog")
+            return
+
+        format_string = setup_dialog.get_format_string()
+        collision_mode = setup_dialog.get_collision_mode()
+
+        log.info(
+            f"Renaming {len(media_files)} files with format {format_string!r} "
+            f"(collision mode: {collision_mode})"
+        )
+
+        dispatcher = RenameDispatcher(self)
+        dispatcher.enqueue(media_files, format_string, collision_mode)
+
+        # Immediate post-completion refresh (before summary dialog shows).
+        dispatcher.analysis_completed.connect(
+            lambda: self._refresh_after_batch(media_files)
+        )
+
+        progress_dialog = AnalyzerProgressDialog(
+            self,
+            dispatcher=dispatcher,
+            title="Renaming Files",
+            cancel_button_text="Cancel Rename",
+            supports_discard=False,
+            cancel_prompt_title="Cancel Rename",
+            cancel_prompt_body=(
+                "Stop renaming remaining files? Files already renamed will "
+                "keep their new names."
+            ),
+        )
+
+        dispatcher.start()
+        result = progress_dialog.exec()
+
+        if result == QDialog.DialogCode.Accepted:
+            summary_dialog = AnalyzerSummaryDialog(
+                self,
+                summary=dispatcher.get_summary(),
+                title="Rename Complete",
+                success_verb="renamed",
+            )
+            # Renames don't support "reselect failed" - the underlying files
+            # may have been renamed or are still at their old names. Hide the
+            # button by not connecting the signal; the dialog still shows it
+            # if there are failures. Acceptable tradeoff; the button just
+            # selects by path.
+            summary_dialog.select_files_requested.connect(
+                self._on_select_analyzer_files
+            )
+            summary_dialog.exec()
+
+            # Full rescan after the user closes the summary, per spec. The
+            # on-completion refresh already updated the list, but a rescan
+            # ensures any new files, timestamps, etc. are picked up cleanly.
+            if self._current_path:
+                self.set_path(self._current_path)
 
     @Slot(list)
     def _on_select_analyzer_files(self, file_paths: list):
@@ -1238,6 +1388,9 @@ class MainWindow(QMainWindow):
         self.action_properties.setEnabled(len(selected_rows) > 0 and is_media_file)
         self.action_play_file.setEnabled(len(selected_rows) == 1 and is_media_file)
         self.action_open_in_file_browser.setEnabled(len(selected_rows) >= 1)
+        self.action_rename_from_metadata.setEnabled(
+            len(selected_rows) > 0 and is_media_file
+        )
         # Save and Reset actions are enabled/disabled by on_autosave_changed
         # but they also require staged changes to be meaningful.
         # We can further refine their state here if needed, e.g., disable if no staged changes.

--- a/src/windows/preferences/rename_presets_pane.py
+++ b/src/windows/preferences/rename_presets_pane.py
@@ -1,0 +1,177 @@
+"""Preferences pane for managing rename format-string presets."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from util.const import RENAME_PRESETS_DEFAULTS
+from windows.preferences.base import PreferencePaneBase
+from windows.rename.setup_dialog import (
+    load_presets_from_settings,
+    save_presets_to_settings,
+)
+
+
+class RenamePresetsPane(PreferencePaneBase):
+    """
+    Lets the user add, remove, reorder, and reset the rename format-string
+    presets that populate the rename setup dialog's preset dropdown.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._setup_ui()
+
+    # -- PreferencePaneBase API ---------------------------------------------
+
+    def get_name(self) -> str:
+        return "Rename Presets"
+
+    def get_icon(self) -> QIcon:
+        return QIcon()  # no icon - the preferences window handles missing icons gracefully
+
+    def load_from_settings(self) -> None:
+        self._populate_list(load_presets_from_settings())
+
+    def save_to_settings(self) -> None:
+        save_presets_to_settings(self._collect_presets())
+
+    def validate(self) -> tuple[bool, str]:
+        # Empty list is allowed; the dropdown will just show "(no presets
+        # defined)". No other validation required - the format-string syntax
+        # is forgiving enough that invalid entries render as text.
+        return True, ""
+
+    def load_defaults(self) -> None:
+        self._populate_list(list(RENAME_PRESETS_DEFAULTS))
+
+    # -- UI -----------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        desc = QLabel(
+            "Manage the list of format-string presets shown in the 'Rename "
+            "Files Based on Metadata' dialog's preset dropdown. See the token "
+            "reference in that dialog for a list of available placeholders."
+        )
+        desc.setWordWrap(True)
+        layout.addWidget(desc)
+
+        body = QHBoxLayout()
+
+        self.list_widget = QListWidget()
+        self.list_widget.setSelectionMode(
+            QListWidget.SelectionMode.SingleSelection
+        )
+        self.list_widget.setEditTriggers(
+            QListWidget.EditTrigger.DoubleClicked
+            | QListWidget.EditTrigger.EditKeyPressed
+        )
+        body.addWidget(self.list_widget, stretch=1)
+
+        button_col = QVBoxLayout()
+        self.add_button = QPushButton("Add...")
+        self.edit_button = QPushButton("Edit...")
+        self.remove_button = QPushButton("Remove")
+        self.up_button = QPushButton("Move Up")
+        self.down_button = QPushButton("Move Down")
+        self.reset_button = QPushButton("Reset to Factory Defaults...")
+
+        for btn in (
+            self.add_button,
+            self.edit_button,
+            self.remove_button,
+            self.up_button,
+            self.down_button,
+        ):
+            button_col.addWidget(btn)
+        button_col.addStretch()
+        button_col.addWidget(self.reset_button)
+        body.addLayout(button_col)
+
+        layout.addLayout(body)
+
+        self.add_button.clicked.connect(self._on_add)
+        self.edit_button.clicked.connect(self._on_edit)
+        self.remove_button.clicked.connect(self._on_remove)
+        self.up_button.clicked.connect(lambda: self._move(-1))
+        self.down_button.clicked.connect(lambda: self._move(+1))
+        self.reset_button.clicked.connect(self._on_reset)
+
+    # -- helpers ------------------------------------------------------------
+
+    def _populate_list(self, presets: list[str]) -> None:
+        self.list_widget.clear()
+        for preset in presets:
+            self._add_item(preset)
+
+    def _add_item(self, text: str) -> None:
+        item = QListWidgetItem(text)
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
+        self.list_widget.addItem(item)
+
+    def _collect_presets(self) -> list[str]:
+        return [
+            self.list_widget.item(i).text().strip()
+            for i in range(self.list_widget.count())
+            if self.list_widget.item(i).text().strip()
+        ]
+
+    # -- button handlers ----------------------------------------------------
+
+    def _on_add(self) -> None:
+        text, ok = QInputDialog.getText(
+            self, "Add Preset", "Format string:", text="%ARTIST% - %TITLE%"
+        )
+        if ok and text.strip():
+            self._add_item(text.strip())
+            self.list_widget.setCurrentRow(self.list_widget.count() - 1)
+
+    def _on_edit(self) -> None:
+        item = self.list_widget.currentItem()
+        if item is None:
+            return
+        text, ok = QInputDialog.getText(
+            self, "Edit Preset", "Format string:", text=item.text()
+        )
+        if ok:
+            text = text.strip()
+            if text:
+                item.setText(text)
+
+    def _on_remove(self) -> None:
+        row = self.list_widget.currentRow()
+        if row >= 0:
+            self.list_widget.takeItem(row)
+
+    def _move(self, delta: int) -> None:
+        row = self.list_widget.currentRow()
+        new_row = row + delta
+        if row < 0 or new_row < 0 or new_row >= self.list_widget.count():
+            return
+        item = self.list_widget.takeItem(row)
+        self.list_widget.insertItem(new_row, item)
+        self.list_widget.setCurrentRow(new_row)
+
+    def _on_reset(self) -> None:
+        confirm = QMessageBox.question(
+            self,
+            "Reset Rename Presets",
+            "Replace the current preset list with the factory defaults? "
+            "Custom presets will be lost.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if confirm == QMessageBox.StandardButton.Yes:
+            self.load_defaults()

--- a/src/windows/preferences_window.py
+++ b/src/windows/preferences_window.py
@@ -11,10 +11,12 @@ from PySide6.QtGui import QKeySequence, QShortcut
 from util.const import (
     SETTINGS_GROUP_GENERAL, SETTINGS_GROUP_ANALYZERS_PREFERRED,
     SETTINGS_GROUP_ANALYZERS_CATEGORY_OPTIONS, SETTINGS_GROUP_RESOURCES,
+    SETTINGS_GROUP_RENAME,
 )
 from windows.preferences.base import PreferencePaneBase
 from windows.preferences.general_pane import GeneralPane
 from windows.preferences.metadata_pane import MetadataPane
+from windows.preferences.rename_presets_pane import RenamePresetsPane
 from windows.preferences.resources_pane import ResourcesPane
 
 
@@ -124,8 +126,9 @@ class PreferencesWindow(QDialog):
         general_pane = GeneralPane()
         metadata_pane = MetadataPane()
         resources_pane = ResourcesPane()
+        rename_presets_pane = RenamePresetsPane()
 
-        self.panes = [general_pane, metadata_pane, resources_pane]
+        self.panes = [general_pane, metadata_pane, resources_pane, rename_presets_pane]
 
         # Add to UI
         for pane in self.panes:
@@ -191,3 +194,6 @@ class PreferencesWindow(QDialog):
 
         # Clear Resources settings
         self.settings.remove(SETTINGS_GROUP_RESOURCES)
+
+        # Clear Rename presets
+        self.settings.remove(SETTINGS_GROUP_RENAME)

--- a/src/windows/rename/__init__.py
+++ b/src/windows/rename/__init__.py
@@ -1,0 +1,1 @@
+"""Dialogs for the 'Rename files based on metadata' feature."""

--- a/src/windows/rename/setup_dialog.py
+++ b/src/windows/rename/setup_dialog.py
@@ -139,8 +139,8 @@ class RenameSetupDialog(QDialog):
         desc = QLabel(
             "Rename selected files using a format string built from their "
             "metadata. Tokens are wrapped in %PERCENT% characters. Enclose a "
-            "segment in [brackets]? to mark it optional - it renders only if "
-            "every token inside has a value. Use :00 inside a token (e.g. "
+            "segment in <angle brackets> to mark it optional - it renders only "
+            "if every token inside has a value. Use :00 inside a token (e.g. "
             "%TRACKNUMBER:00%) to pad numbers with leading zeros."
         )
         desc.setWordWrap(True)

--- a/src/windows/rename/setup_dialog.py
+++ b/src/windows/rename/setup_dialog.py
@@ -1,0 +1,364 @@
+"""Rename setup dialog - lets the user compose a format string and preview results.
+
+Responsibilities:
+- Compose a format string (with preset dropdown, token reference button).
+- Show a live single-line example using SAMPLE_RENAME_METADATA (updates on
+  every keystroke).
+- Show a preview table of the selected files (up to ~12 rows); refreshes
+  when the textbox loses focus.
+- Let the user choose collision behavior.
+
+The dialog does NOT perform renames - it just returns the configured values
+so the MainWindow can drive a RenameDispatcher.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMenu,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from models.settings import get_qsettings
+from util.const import (
+    RENAME_COLLISION_MODE_DEFAULT,
+    RENAME_COLLISION_MODE_LABELS,
+    RENAME_PRESETS_DEFAULTS,
+    SAMPLE_RENAME_EXTENSION,
+    SAMPLE_RENAME_METADATA,
+    SETTINGS_ARRAY_RENAME_PRESETS,
+    SETTINGS_GROUP_RENAME,
+    SETTINGS_RENAME_COLLISION_MODE,
+)
+from util.logging import log
+from util.rename_formatter import (
+    FormatParseError,
+    build_token_map_from_dict,
+    format_filename,
+    sanitize_filename,
+    validate_format_string,
+)
+from windows.rename.token_reference_dialog import TokenReferenceDialog
+
+if TYPE_CHECKING:
+    from models.media_file import MediaFile
+
+
+# Cap for the preview table - renaming 10k+ files shouldn't lock the dialog up.
+PREVIEW_ROW_LIMIT = 12
+
+
+def load_presets_from_settings() -> list[str]:
+    """Load the user's format-string presets from QSettings."""
+    settings = get_qsettings()
+    settings.beginGroup(SETTINGS_GROUP_RENAME)
+    size = settings.beginReadArray(SETTINGS_ARRAY_RENAME_PRESETS)
+    presets: list[str] = []
+    for i in range(size):
+        settings.setArrayIndex(i)
+        value = settings.value("value", "", type=str)
+        if value:
+            presets.append(value)
+    settings.endArray()
+    settings.endGroup()
+    if not presets:
+        # First run: seed with factory defaults so the dropdown isn't empty.
+        return list(RENAME_PRESETS_DEFAULTS)
+    return presets
+
+
+def save_presets_to_settings(presets: list[str]) -> None:
+    """Persist the user's format-string presets to QSettings."""
+    settings = get_qsettings()
+    settings.beginGroup(SETTINGS_GROUP_RENAME)
+    # Clear the existing array entirely before writing.
+    settings.remove(SETTINGS_ARRAY_RENAME_PRESETS)
+    settings.beginWriteArray(SETTINGS_ARRAY_RENAME_PRESETS, len(presets))
+    for i, value in enumerate(presets):
+        settings.setArrayIndex(i)
+        settings.setValue("value", value)
+    settings.endArray()
+    settings.endGroup()
+
+
+class RenameSetupDialog(QDialog):
+    """Configuration dialog for the rename-by-metadata feature."""
+
+    def __init__(
+        self,
+        media_files: list["MediaFile"],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Rename Files Based on Metadata")
+        self.setModal(True)
+        self.resize(720, 560)
+
+        self._media_files = list(media_files)
+        self._sample_tokens = build_token_map_from_dict(SAMPLE_RENAME_METADATA)
+        self._qsettings = get_qsettings()
+        self._presets = load_presets_from_settings()
+
+        self._setup_ui()
+        self._connect_signals()
+        self._refresh_sample_label()
+        self._refresh_preview_table()
+
+    # -- public accessors ---------------------------------------------------
+
+    def get_format_string(self) -> str:
+        return self.format_edit.text()
+
+    def get_collision_mode(self) -> str:
+        return self.collision_combo.currentData()
+
+    # -- UI construction ----------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        # Description.
+        desc = QLabel(
+            "Rename selected files using a format string built from their "
+            "metadata. Tokens are wrapped in %PERCENT% characters. Enclose a "
+            "segment in [brackets]? to mark it optional - it renders only if "
+            "every token inside has a value. Use :00 inside a token (e.g. "
+            "%TRACKNUMBER:00%) to pad numbers with leading zeros."
+        )
+        desc.setWordWrap(True)
+        layout.addWidget(desc)
+
+        # Format string row.
+        fmt_row = QHBoxLayout()
+        fmt_row.addWidget(QLabel("Format:"))
+        self.format_edit = QLineEdit()
+        # Seed with the first preset so the user sees something meaningful.
+        if self._presets:
+            self.format_edit.setText(self._presets[0])
+        fmt_row.addWidget(self.format_edit, stretch=1)
+
+        self.presets_button = QToolButton()
+        self.presets_button.setText("Presets \u25be")
+        self.presets_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.presets_button.setMenu(self._build_presets_menu())
+        fmt_row.addWidget(self.presets_button)
+
+        self.tokens_button = QPushButton("Show token reference...")
+        fmt_row.addWidget(self.tokens_button)
+
+        layout.addLayout(fmt_row)
+
+        # Live sample label.
+        self.sample_label = QLabel("Example: ")
+        self.sample_label.setStyleSheet("color: #555; font-style: italic;")
+        self.sample_label.setWordWrap(True)
+        self.sample_label.setToolTip(
+            "Live preview using sample metadata from track 7, disc 1 of "
+            "Dieselboy's 'The Dungeonmaster's Guide' (Raiden - Infection, "
+            "E-Sassin Remix). Updates as you type."
+        )
+        layout.addWidget(self.sample_label)
+
+        # Preview table.
+        preview_header = QLabel("Preview (updates when the format field loses focus):")
+        layout.addWidget(preview_header)
+
+        self.preview_table = QTableWidget()
+        self.preview_table.setColumnCount(2)
+        self.preview_table.setHorizontalHeaderLabels(["Current name", "New name"])
+        self.preview_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.preview_table.setSelectionBehavior(
+            QTableWidget.SelectionBehavior.SelectRows
+        )
+        self.preview_table.verticalHeader().setVisible(False)
+        self.preview_table.setAlternatingRowColors(True)
+        ph = self.preview_table.horizontalHeader()
+        ph.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        ph.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        layout.addWidget(self.preview_table, stretch=1)
+
+        self.preview_hint = QLabel()
+        self.preview_hint.setStyleSheet("color: #777; font-size: 10px;")
+        layout.addWidget(self.preview_hint)
+
+        # Collision mode row.
+        col_row = QHBoxLayout()
+        col_row.addWidget(QLabel("If target exists:"))
+        self.collision_combo = QComboBox()
+        for mode_id, label in RENAME_COLLISION_MODE_LABELS.items():
+            self.collision_combo.addItem(label, mode_id)
+        saved_mode = self._qsettings.value(
+            SETTINGS_RENAME_COLLISION_MODE,
+            RENAME_COLLISION_MODE_DEFAULT,
+            type=str,
+        )
+        idx = self.collision_combo.findData(saved_mode)
+        if idx >= 0:
+            self.collision_combo.setCurrentIndex(idx)
+        col_row.addWidget(self.collision_combo, stretch=1)
+        layout.addLayout(col_row)
+
+        # OK / Cancel buttons.
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        self.button_box.accepted.connect(self._on_accepted)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def _build_presets_menu(self) -> QMenu:
+        menu = QMenu(self)
+        for preset in self._presets:
+            action = QAction(preset, self)
+            action.triggered.connect(lambda checked=False, p=preset: self._apply_preset(p))
+            menu.addAction(action)
+        if not self._presets:
+            empty = QAction("(no presets defined)", self)
+            empty.setEnabled(False)
+            menu.addAction(empty)
+        menu.addSeparator()
+        manage = QAction("Manage presets in Preferences...", self)
+        manage.triggered.connect(self._on_manage_presets)
+        menu.addAction(manage)
+        return menu
+
+    # -- signal wiring ------------------------------------------------------
+
+    def _connect_signals(self) -> None:
+        self.format_edit.textChanged.connect(self._refresh_sample_label)
+        self.format_edit.editingFinished.connect(self._refresh_preview_table)
+        self.tokens_button.clicked.connect(self._on_show_tokens)
+
+    # -- actions ------------------------------------------------------------
+
+    def _apply_preset(self, preset: str) -> None:
+        self.format_edit.setText(preset)
+        self._refresh_preview_table()
+
+    def _on_show_tokens(self) -> None:
+        dlg = TokenReferenceDialog(self)
+        dlg.exec()
+
+    def _on_manage_presets(self) -> None:
+        QMessageBox.information(
+            self,
+            "Manage Presets",
+            "Open the Preferences window and select 'Rename Presets' to "
+            "add, remove, or reorder your format-string presets.",
+        )
+
+    # -- live updates -------------------------------------------------------
+
+    def _render_for_tokens(self, fmt: str, tokens: dict[str, str]) -> tuple[str, str]:
+        """
+        Render a format string against a token map, returning (preview, error).
+
+        preview is the sanitized filename (extension appended) or an error
+        marker in angle brackets. error is an optional human-readable error.
+        """
+        ok, msg = validate_format_string(fmt)
+        if not ok:
+            return ("<invalid format>", msg)
+        try:
+            rendered = format_filename(fmt, tokens)
+        except FormatParseError as e:
+            return ("<invalid format>", str(e))
+        sanitized = sanitize_filename(rendered)
+        if not sanitized:
+            return ("<empty filename>", "Format string rendered to an empty filename")
+        return (sanitized, "")
+
+    def _refresh_sample_label(self) -> None:
+        fmt = self.format_edit.text()
+        if not fmt:
+            self.sample_label.setText("Example: (enter a format string above)")
+            self._set_ok_enabled(False)
+            return
+        preview, error = self._render_for_tokens(fmt, self._sample_tokens)
+        if error and preview.startswith("<"):
+            self.sample_label.setText(f"Example: {preview} - {error}")
+            self._set_ok_enabled(False)
+            return
+        self.sample_label.setText(f"Example: {preview}{SAMPLE_RENAME_EXTENSION}")
+        self._set_ok_enabled(True)
+
+    def _set_ok_enabled(self, enabled: bool) -> None:
+        ok_button = self.button_box.button(QDialogButtonBox.StandardButton.Ok)
+        if ok_button is not None:
+            ok_button.setEnabled(enabled)
+
+    def _refresh_preview_table(self) -> None:
+        fmt = self.format_edit.text()
+        files_to_show = self._media_files[:PREVIEW_ROW_LIMIT]
+        self.preview_table.setRowCount(len(files_to_show))
+
+        for row, mf in enumerate(files_to_show):
+            try:
+                from util.rename_formatter import build_token_map
+                tokens = build_token_map(mf)
+            except Exception as e:
+                log.warning(f"Failed to build token map for {mf.file_path}: {e}")
+                tokens = {}
+
+            current_name = os.path.basename(mf.file_path)
+            ext = os.path.splitext(current_name)[1]
+
+            if not fmt:
+                new_name = "(enter a format string)"
+            else:
+                preview, error = self._render_for_tokens(fmt, tokens)
+                if error and preview.startswith("<"):
+                    new_name = preview
+                else:
+                    new_name = f"{preview}{ext}"
+
+            cur_item = QTableWidgetItem(current_name)
+            new_item = QTableWidgetItem(new_name)
+            self.preview_table.setItem(row, 0, cur_item)
+            self.preview_table.setItem(row, 1, new_item)
+
+        total = len(self._media_files)
+        if total > PREVIEW_ROW_LIMIT:
+            self.preview_hint.setText(
+                f"Showing {PREVIEW_ROW_LIMIT} of {total} selected files."
+            )
+        else:
+            self.preview_hint.setText(f"{total} file(s) selected.")
+
+    # -- accept -------------------------------------------------------------
+
+    def _on_accepted(self) -> None:
+        fmt = self.format_edit.text().strip()
+        if not fmt:
+            QMessageBox.warning(
+                self, "Invalid Format", "Enter a format string before continuing."
+            )
+            return
+        ok, msg = validate_format_string(fmt)
+        if not ok:
+            QMessageBox.warning(self, "Invalid Format", msg)
+            return
+
+        # Persist the collision-mode choice so the dropdown remembers it next time.
+        self._qsettings.setValue(
+            SETTINGS_RENAME_COLLISION_MODE, self.get_collision_mode()
+        )
+        self.accept()

--- a/src/windows/rename/token_reference_dialog.py
+++ b/src/windows/rename/token_reference_dialog.py
@@ -1,0 +1,100 @@
+"""Token reference dialog for the rename feature.
+
+A read-only, sectioned table of every token the format string supports. Rows
+are copyable so the user can grab tokens directly with Ctrl+C.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QBrush, QColor, QFont
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from util.rename_formatter import list_tokens_by_section
+
+
+class TokenReferenceDialog(QDialog):
+    """Simple dialog showing every supported rename token grouped by section."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Rename Tokens")
+        self.setModal(True)
+        self.resize(520, 560)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        header = QLabel(
+            "Insert any of these tokens into the format string to substitute "
+            "the corresponding metadata value. Rows are selectable and can be "
+            "copied with Ctrl+C."
+        )
+        header.setWordWrap(True)
+        layout.addWidget(header)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(2)
+        self.table.setHorizontalHeaderLabels(["Token", "Field"])
+        self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setAlternatingRowColors(True)
+
+        h = self.table.horizontalHeader()
+        h.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        h.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+
+        self._populate_table()
+        layout.addWidget(self.table)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.setDefault(True)
+        close_btn.clicked.connect(self.accept)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
+
+    def _populate_table(self) -> None:
+        """Populate the table, with bold non-selectable rows as section headers."""
+        sections = list_tokens_by_section()
+
+        total_rows = sum(len(rows) + 1 for rows in sections.values())  # +1 header per section
+        self.table.setRowCount(total_rows)
+
+        bold = QFont()
+        bold.setBold(True)
+        header_brush = QBrush(QColor(220, 220, 220))
+
+        row = 0
+        for section, entries in sections.items():
+            # Section header row spans both columns.
+            hdr_item = QTableWidgetItem(section)
+            hdr_item.setFont(bold)
+            hdr_item.setBackground(header_brush)
+            hdr_item.setFlags(Qt.ItemFlag.ItemIsEnabled)  # non-selectable
+            self.table.setItem(row, 0, hdr_item)
+            blank = QTableWidgetItem("")
+            blank.setBackground(header_brush)
+            blank.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            self.table.setItem(row, 1, blank)
+            row += 1
+
+            for token, description in entries:
+                token_item = QTableWidgetItem(token)
+                desc_item = QTableWidgetItem(description)
+                self.table.setItem(row, 0, token_item)
+                self.table.setItem(row, 1, desc_item)
+                row += 1

--- a/src/workers/rename_dispatcher.py
+++ b/src/workers/rename_dispatcher.py
@@ -1,0 +1,415 @@
+"""
+Rename dispatcher for renaming media files based on a format string.
+
+The dispatcher is intentionally shaped like AnalyzerDispatcher so the existing
+AnalyzerProgressDialog and AnalyzerSummaryDialog can consume it by duck typing.
+Unlike the analyzer dispatcher, renames are quick filesystem operations, so
+this runs tasks serially in a single QRunnable via the global thread pool.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import QObject, QRunnable, Signal, Slot, QThreadPool
+
+from models.media_file import MediaFile
+from util.const import (
+    RENAME_COLLISION_AUTO_DISAMBIGUATE,
+    RENAME_COLLISION_OVERWRITE,
+    RENAME_COLLISION_SKIP,
+)
+from util.logging import log
+from util.rename_formatter import (
+    FormatParseError,
+    build_token_map,
+    format_filename,
+    sanitize_filename,
+)
+
+
+# Label shown in the progress dialog's per-file list. Mirrors an analyzer name.
+RENAME_TASK_LABEL = "Rename"
+
+# Safety cap for auto-disambiguation iteration.
+_MAX_DISAMBIG_SUFFIX = 999
+
+
+@dataclass
+class RenameResult:
+    """Outcome of a single rename task."""
+
+    success: bool = False
+    skipped: bool = False
+    error: str = ""
+    new_path: str = ""
+
+
+@dataclass
+class RenameTask:
+    """A single file-rename task."""
+
+    media_file: MediaFile
+    target_basename: str  # without extension, may be empty if rendering failed
+    extension: str
+    collision_mode: str
+    # Populated at planning time so within-batch collisions can be resolved up
+    # front and surfaced in the preview.
+    target_path: str = ""
+    result: RenameResult | None = None
+
+
+@dataclass
+class RenameSummary:
+    """Summary of a completed rename batch - matches AnalyzerDispatcher's shape."""
+
+    total: int = 0
+    successful: int = 0
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "successful": self.successful,
+            "failed": list(self.failed),
+            "skipped": list(self.skipped),
+        }
+
+
+class _RenameWorkerSignals(QObject):
+    """Internal cross-thread signal bus."""
+
+    worker_finished = Signal(int, object)  # (worker_id, RenameTask)
+
+
+class _RenameWorker(QRunnable):
+    """Runs a single rename operation in a worker thread."""
+
+    def __init__(self, task: RenameTask, signals: _RenameWorkerSignals, worker_id: int):
+        super().__init__()
+        self.task = task
+        self.signals = signals
+        self.worker_id = worker_id
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            source = self.task.media_file.file_path
+            destination = self.task.target_path
+
+            if not destination:
+                self.task.result = RenameResult(
+                    success=False,
+                    error="Rendered filename is empty after sanitization",
+                )
+            elif os.path.abspath(source) == os.path.abspath(destination):
+                # No-op: new name matches current. Treat as a skip so the
+                # summary tells the user nothing changed.
+                self.task.result = RenameResult(
+                    success=True,
+                    skipped=True,
+                    error="Source and target filenames are identical",
+                    new_path=destination,
+                )
+            else:
+                final_dest = self._resolve_destination(source, destination)
+                if final_dest is None:
+                    # Skip mode with an existing target.
+                    self.task.result = RenameResult(
+                        success=False,
+                        error=f"Target file already exists: "
+                              f"{os.path.basename(destination)}",
+                    )
+                else:
+                    if self.task.collision_mode == RENAME_COLLISION_OVERWRITE:
+                        os.replace(source, final_dest)
+                    else:
+                        os.rename(source, final_dest)
+                    # Update the MediaFile's cached path so the UI can reflect it.
+                    self.task.media_file._file_path = final_dest
+                    self.task.result = RenameResult(
+                        success=True, new_path=final_dest
+                    )
+                    log.info(f"Renamed {source} -> {final_dest}")
+
+        except Exception as e:
+            log.error(f"Rename failed for {self.task.media_file.file_path}: {e}",
+                      exc_info=True)
+            self.task.result = RenameResult(
+                success=False, error=f"Unexpected error: {e}"
+            )
+
+        self.signals.worker_finished.emit(self.worker_id, self.task)
+
+    def _resolve_destination(self, source: str, destination: str) -> str | None:
+        """
+        Apply the task's collision policy against on-disk state.
+
+        Returns the final destination path to use, or None if the task should
+        be treated as a failure (skip mode with existing target).
+        """
+        mode = self.task.collision_mode
+        if not os.path.exists(destination):
+            return destination
+
+        if mode == RENAME_COLLISION_OVERWRITE:
+            return destination
+        if mode == RENAME_COLLISION_SKIP:
+            return None
+        # Auto-disambiguate: append " (2)", " (3)", ... before the extension.
+        base, ext = os.path.splitext(destination)
+        for n in range(2, _MAX_DISAMBIG_SUFFIX + 1):
+            candidate = f"{base} ({n}){ext}"
+            if not os.path.exists(candidate):
+                return candidate
+        return None
+
+
+def plan_rename(
+    media_file: MediaFile, format_string: str, collision_mode: str
+) -> RenameTask:
+    """
+    Build a RenameTask for a single file, computing the intended target basename.
+
+    The returned task has .target_path populated (joined with the original
+    directory and the original extension). On render failure, target_basename
+    and target_path are left empty; the worker will mark the task failed.
+    """
+    source = media_file.file_path
+    directory = os.path.dirname(source)
+    extension = os.path.splitext(source)[1]
+    try:
+        tokens = build_token_map(media_file)
+        rendered = format_filename(format_string, tokens)
+    except FormatParseError as e:
+        log.warning(f"Format parse error for {source}: {e}")
+        return RenameTask(
+            media_file=media_file,
+            target_basename="",
+            extension=extension,
+            collision_mode=collision_mode,
+            target_path="",
+        )
+
+    basename = sanitize_filename(rendered)
+    if not basename:
+        return RenameTask(
+            media_file=media_file,
+            target_basename="",
+            extension=extension,
+            collision_mode=collision_mode,
+            target_path="",
+        )
+
+    target_path = os.path.join(directory, basename + extension)
+    return RenameTask(
+        media_file=media_file,
+        target_basename=basename,
+        extension=extension,
+        collision_mode=collision_mode,
+        target_path=target_path,
+    )
+
+
+def resolve_within_batch_collisions(tasks: list[RenameTask]) -> None:
+    """
+    When multiple tasks in a batch target the same path, adjust them in-place
+    according to each task's collision mode.
+
+    - Auto-disambiguate: append " (2)", " (3)" suffixes so all targets are unique.
+    - Skip: mark later duplicates with a preset failing result.
+    - Overwrite: leave as-is (last write wins at run time).
+    """
+    # Group by target_path for tasks that have a non-empty target.
+    seen: dict[str, list[RenameTask]] = {}
+    for task in tasks:
+        if not task.target_path:
+            continue
+        seen.setdefault(os.path.abspath(task.target_path).lower(), []).append(task)
+
+    for _, bucket in seen.items():
+        if len(bucket) <= 1:
+            continue
+        mode = bucket[0].collision_mode
+        if mode == RENAME_COLLISION_AUTO_DISAMBIGUATE:
+            # First task keeps the original; subsequent get " (2)", " (3)", ...
+            for i, task in enumerate(bucket[1:], start=2):
+                base, ext = os.path.splitext(task.target_path)
+                task.target_path = f"{base} ({i}){ext}"
+                task.target_basename = f"{task.target_basename} ({i})"
+        elif mode == RENAME_COLLISION_SKIP:
+            for task in bucket[1:]:
+                task.result = RenameResult(
+                    success=False,
+                    error=(f"Another file in this batch also targets "
+                           f"'{os.path.basename(task.target_path)}'"),
+                )
+
+
+class RenameDispatcher(QObject):
+    """
+    Queue + runner for a batch of file-rename operations.
+
+    Exposes the same signals and get_summary() shape as AnalyzerDispatcher so
+    the analyzer progress/summary dialogs can drive it directly.
+    """
+
+    # Signal names intentionally mirror AnalyzerDispatcher's so the dialogs
+    # can connect to either without branching. "analysis_*" is a misnomer
+    # for renames but consolidates the dialog's signal-connection code.
+    analysis_started = Signal()
+    analysis_completed = Signal()
+    task_started = Signal(str, str)  # (file_path, RENAME_TASK_LABEL)
+    task_completed = Signal(str, object)  # (file_path, RenameResult)
+    progress_updated = Signal(int, int)  # (completed, total)
+    active_tasks_updated = Signal(list)  # [(file_path, label)]
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self.queue: list[RenameTask] = []
+        self.completed_tasks: list[RenameTask] = []
+        self._is_running = False
+        self._active_workers = 0
+        self._next_worker_id = 0
+        self._cancelled = False
+
+        # Background threads emit through these signals so result application
+        # happens on the main thread.
+        self._signals = _RenameWorkerSignals()
+        self._signals.worker_finished.connect(self._on_worker_finished)
+
+        self._thread_pool = QThreadPool.globalInstance()
+
+    # -- public API ---------------------------------------------------------
+
+    def enqueue(
+        self,
+        media_files: list[MediaFile],
+        format_string: str,
+        collision_mode: str,
+    ) -> None:
+        """
+        Plan a rename for each media file and enqueue the resulting tasks.
+
+        Tasks whose rendering fails (parse error, empty sanitized result) are
+        pre-marked as failures and skipped over at run time.
+        """
+        tasks = [plan_rename(mf, format_string, collision_mode) for mf in media_files]
+        resolve_within_batch_collisions(tasks)
+
+        for task in tasks:
+            if task.result is not None:
+                # Already failed during planning; surface in summary.
+                self.completed_tasks.append(task)
+            elif not task.target_path:
+                task.result = RenameResult(
+                    success=False,
+                    error="Format string rendered to an empty/invalid filename",
+                )
+                self.completed_tasks.append(task)
+            else:
+                self.queue.append(task)
+
+        log.info(f"Rename dispatcher enqueued {len(self.queue)} runnable tasks, "
+                 f"{len(self.completed_tasks)} pre-failed")
+
+    def start(self) -> None:
+        """Begin processing the queue."""
+        if self._is_running:
+            log.warning("Rename dispatcher already running")
+            return
+        if not self.queue and not self.completed_tasks:
+            log.info("Rename dispatcher has nothing to do")
+            return
+
+        self._is_running = True
+        self._cancelled = False
+        self.analysis_started.emit()
+
+        total = len(self.queue) + len(self.completed_tasks)
+        self.progress_updated.emit(len(self.completed_tasks), total)
+
+        if not self.queue:
+            # Everything pre-failed; nothing to run.
+            self._finish()
+            return
+
+        self._process_next()
+
+    def cancel_all(self) -> None:
+        """Drain remaining queued tasks; in-flight tasks complete naturally."""
+        log.info("Rename dispatcher cancelling remaining tasks")
+        self._cancelled = True
+        cancelled = self.queue
+        self.queue = []
+        for task in cancelled:
+            task.result = RenameResult(
+                success=False, skipped=True, error="Cancelled by user"
+            )
+            self.completed_tasks.append(task)
+        if self._active_workers == 0:
+            self._finish()
+
+    def get_summary(self) -> dict[str, Any]:
+        """Return a summary dict matching AnalyzerDispatcher.get_summary()."""
+        summary = RenameSummary()
+        summary.total = len(self.completed_tasks)
+        for task in self.completed_tasks:
+            if task.result is None:
+                continue
+            path = task.media_file.file_path
+            if task.result.skipped:
+                summary.skipped.append((path, task.result.error))
+            elif task.result.success:
+                summary.successful += 1
+            else:
+                summary.failed.append((path, task.result.error))
+        return summary.as_dict()
+
+    # -- internals ----------------------------------------------------------
+
+    def _process_next(self) -> None:
+        """Launch the next queued task. Serial: only one worker at a time."""
+        if not self._is_running:
+            return
+        if self._cancelled or not self.queue:
+            if self._active_workers == 0:
+                self._finish()
+            return
+
+        task = self.queue.pop(0)
+        worker_id = self._next_worker_id
+        self._next_worker_id += 1
+        self._active_workers += 1
+
+        self.task_started.emit(task.media_file.file_path, RENAME_TASK_LABEL)
+        self.active_tasks_updated.emit(
+            [(task.media_file.file_path, RENAME_TASK_LABEL)]
+        )
+
+        worker = _RenameWorker(task, self._signals, worker_id)
+        self._thread_pool.start(worker)
+
+    @Slot(int, object)
+    def _on_worker_finished(self, worker_id: int, task: RenameTask) -> None:
+        self._active_workers -= 1
+        if task.result is None:
+            task.result = RenameResult(
+                success=False, error="Worker returned without a result"
+            )
+        self.completed_tasks.append(task)
+
+        self.task_completed.emit(task.media_file.file_path, task.result)
+        total = len(self.queue) + len(self.completed_tasks)
+        self.progress_updated.emit(len(self.completed_tasks), total)
+        self.active_tasks_updated.emit([])
+
+        self._process_next()
+
+    def _finish(self) -> None:
+        self._is_running = False
+        self.analysis_completed.emit()

--- a/tests/util/test_rename_formatter.py
+++ b/tests/util/test_rename_formatter.py
@@ -70,20 +70,20 @@ def test_padding_negative_number():
 def test_optional_section_renders_when_present():
     tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection",
                             REMIXER="E-Sassin")
-    out = format_filename("%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?", tokens)
+    out = format_filename("%ARTIST% - %TITLE%< (%REMIXER% Remix)>", tokens)
     assert out == "Raiden - Infection (E-Sassin Remix)"
 
 
 def test_optional_section_collapses_when_any_token_missing():
     tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection", REMIXER="")
-    out = format_filename("%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?", tokens)
+    out = format_filename("%ARTIST% - %TITLE%< (%REMIXER% Remix)>", tokens)
     assert out == "Raiden - Infection"
 
 
 def test_nested_optional_section_collapse_preserves_parent():
     # Exact example from the spec: empty ALBUMARTIST must NOT prevent the
     # outer section from rendering.
-    fmt = "[[%ALBUMARTIST% - ]? %ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    fmt = "<<%ALBUMARTIST% - > %ALBUM% - %TRACKNUMBER%> %ARTIST% - %TITLE%"
     tokens = _simple_tokens(
         ALBUMARTIST="", ALBUM="Guide", TRACKNUMBER="7",
         ARTIST="Raiden", TITLE="Infection",
@@ -95,7 +95,7 @@ def test_nested_optional_section_collapse_preserves_parent():
 
 
 def test_nested_optional_section_fully_present():
-    fmt = "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    fmt = "<<%ALBUMARTIST% - >%ALBUM% - %TRACKNUMBER%> %ARTIST% - %TITLE%"
     tokens = _simple_tokens(
         ALBUMARTIST="Dieselboy", ALBUM="Guide", TRACKNUMBER="7",
         ARTIST="Raiden", TITLE="Infection",
@@ -105,7 +105,7 @@ def test_nested_optional_section_fully_present():
 
 
 def test_nested_optional_outer_collapses_when_direct_token_missing():
-    fmt = "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    fmt = "<<%ALBUMARTIST% - >%ALBUM% - %TRACKNUMBER%> %ARTIST% - %TITLE%"
     tokens = _simple_tokens(
         ALBUMARTIST="Dieselboy", ALBUM="", TRACKNUMBER="7",
         ARTIST="Raiden", TITLE="Infection",
@@ -117,16 +117,25 @@ def test_nested_optional_outer_collapses_when_direct_token_missing():
 
 def test_unterminated_optional_raises():
     try:
-        format_filename("[%ARTIST% - %TITLE%", _simple_tokens(ARTIST="x", TITLE="y"))
+        format_filename("<%ARTIST% - %TITLE%", _simple_tokens(ARTIST="x", TITLE="y"))
     except FormatParseError:
         return
     raise AssertionError("Expected FormatParseError")
 
 
-def test_literal_bracket_without_question_mark():
-    tokens = _simple_tokens(ARTIST="Raiden")
-    # A bare ']' at the top level is a literal.
+def test_literal_square_brackets():
+    tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection")
+    # Square brackets are plain literals - no special meaning in the new
+    # syntax. Users can freely include them in filenames.
+    assert format_filename("[%ARTIST%] %TITLE%", tokens) == "[Raiden] Infection"
+    assert format_filename("[]", tokens) == "[]"
     assert format_filename("%ARTIST%]", tokens) == "Raiden]"
+
+
+def test_literal_closing_angle_bracket_at_top_level():
+    tokens = _simple_tokens(ARTIST="Raiden")
+    # A '>' with no matching '<' on the stack renders as a literal.
+    assert format_filename("%ARTIST%>", tokens) == "Raiden>"
 
 
 def test_literal_percent():
@@ -196,7 +205,7 @@ def test_list_tokens_by_section_has_both_sections():
 
 
 def test_validate_format_string_reports_parse_errors():
-    ok, msg = validate_format_string("[%ARTIST% - %TITLE%")
+    ok, msg = validate_format_string("<%ARTIST% - %TITLE%")
     assert ok is False
     assert msg
 
@@ -216,7 +225,7 @@ def test_validate_format_string_rejects_multiple_unknown_tokens():
 
 
 def test_validate_format_string_rejects_unknown_token_inside_optional():
-    ok, msg = validate_format_string("[%NOTATHING% - ]?%ARTIST%")
+    ok, msg = validate_format_string("<%NOTATHING% - >%ARTIST%")
     assert ok is False
     assert "NOTATHING" in msg
 
@@ -229,6 +238,6 @@ def test_validate_format_string_accepts_valid():
 
 def test_end_to_end_sample_metadata():
     tokens = build_token_map_from_dict(SAMPLE_RENAME_METADATA)
-    fmt = "[%TRACKNUMBER:00% - ]?%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?"
+    fmt = "<%TRACKNUMBER:00% - >%ARTIST% - %TITLE%< (%REMIXER% Remix)>"
     out = format_filename(fmt, tokens)
     assert out == "07 - Raiden - Infection (E-Sassin Remix)"

--- a/tests/util/test_rename_formatter.py
+++ b/tests/util/test_rename_formatter.py
@@ -67,6 +67,60 @@ def test_padding_negative_number():
     assert format_filename("%TRACKNUMBER:000%", tokens) == "-003"
 
 
+def test_integer_pad_preserves_decimal_portion():
+    # :000 only pads the integer portion. Decimals in the actual value are
+    # never truncated.
+    tokens = {"BPM": "174.5"}
+    assert format_filename("%BPM:000%", tokens) == "174.5"
+    tokens = {"BPM": "90.5"}
+    assert format_filename("%BPM:000%", tokens) == "090.5"
+
+
+def test_decimal_pad_forces_decimal_on_integer_value():
+    # Integer value with :000.0 picks up a ".0" suffix and padding.
+    tokens = {"BPM": "174"}
+    assert format_filename("%BPM:000.0%", tokens) == "174.0"
+    tokens = {"BPM": "90"}
+    assert format_filename("%BPM:000.0%", tokens) == "090.0"
+
+
+def test_decimal_pad_preserves_existing_decimals_beyond_minimum():
+    # The decimal-pad count is a minimum; extra decimals survive untouched.
+    tokens = {"BPM": "174.55"}
+    assert format_filename("%BPM:000.0%", tokens) == "174.55"
+
+
+def test_decimal_pad_pads_fractional_to_requested_width():
+    tokens = {"BPM": "90.5"}
+    assert format_filename("%BPM:000.000%", tokens) == "090.500"
+
+
+def test_no_pad_spec_renders_value_as_is():
+    # Plain %BPM% never modifies a decimal value.
+    tokens = {"BPM": "174.5"}
+    assert format_filename("%BPM%", tokens) == "174.5"
+    tokens = {"BPM": "174"}
+    assert format_filename("%BPM%", tokens) == "174"
+
+
+def test_decimal_pad_on_non_numeric_is_no_op():
+    # Non-numeric values still render verbatim even with a decimal spec.
+    tokens = _simple_tokens(ARTIST="Raiden")
+    assert format_filename("%ARTIST:000.0%", tokens) == "Raiden"
+
+
+def test_decimal_pad_exceeded_by_value_unchanged_integer():
+    # Integer portion wider than pad width renders unchanged; decimal still
+    # gets forced to the minimum width.
+    tokens = {"BPM": "1000"}
+    assert format_filename("%BPM:000.0%", tokens) == "1000.0"
+
+
+def test_decimal_pad_with_negative_value():
+    tokens = {"BPM": "-5.25"}
+    assert format_filename("%BPM:000.0%", tokens) == "-005.25"
+
+
 def test_initialkey_pads_leading_digits_of_camelot_notation():
     # "7A" with :00 -> "07A". The Camelot special case pads the numeric
     # prefix while preserving the trailing letter.

--- a/tests/util/test_rename_formatter.py
+++ b/tests/util/test_rename_formatter.py
@@ -1,0 +1,220 @@
+"""Tests for util.rename_formatter."""
+from util.rename_formatter import (
+    FormatParseError,
+    build_token_map_from_dict,
+    format_filename,
+    list_tokens_by_section,
+    sanitize_filename,
+    validate_format_string,
+)
+from util.const import (
+    KEY_ALBUM,
+    KEY_ALBUM_ARTIST,
+    KEY_ARTIST,
+    KEY_REMIXER,
+    KEY_TITLE,
+    KEY_TRACK_NUMBER,
+    RENAME_SECTION_STREAM_INFO,
+    RENAME_SECTION_TAGS,
+    SAMPLE_RENAME_METADATA,
+)
+
+
+def _simple_tokens(**overrides):
+    base = {"ARTIST": "", "TITLE": "", "ALBUM": "", "ALBUMARTIST": "",
+            "TRACKNUMBER": "", "REMIXER": "", "YEAR": ""}
+    base.update(overrides)
+    return base
+
+
+def test_plain_token_substitution():
+    tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection")
+    assert format_filename("%ARTIST% - %TITLE%", tokens) == "Raiden - Infection"
+
+
+def test_token_matching_is_case_insensitive():
+    tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection")
+    assert format_filename("%artist% - %Title%", tokens) == "Raiden - Infection"
+
+
+def test_unknown_token_renders_empty():
+    tokens = _simple_tokens(ARTIST="Raiden")
+    assert format_filename("%ARTIST% - %NOPE%", tokens) == "Raiden - "
+
+
+def test_padding_numeric_value():
+    tokens = _simple_tokens(TRACKNUMBER="7")
+    assert format_filename("%TRACKNUMBER:00%", tokens) == "07"
+
+
+def test_padding_value_exceeds_width_renders_unchanged():
+    tokens = _simple_tokens(TRACKNUMBER="125")
+    assert format_filename("%TRACKNUMBER:00%", tokens) == "125"
+
+
+def test_padding_non_numeric_renders_unchanged():
+    tokens = _simple_tokens(TRACKNUMBER="abc")
+    assert format_filename("%TRACKNUMBER:00%", tokens) == "abc"
+
+
+def test_padding_empty_value_stays_empty():
+    tokens = _simple_tokens(TRACKNUMBER="")
+    assert format_filename("%TRACKNUMBER:00%", tokens) == ""
+
+
+def test_padding_negative_number():
+    tokens = _simple_tokens(TRACKNUMBER="-3")
+    assert format_filename("%TRACKNUMBER:000%", tokens) == "-003"
+
+
+def test_optional_section_renders_when_present():
+    tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection",
+                            REMIXER="E-Sassin")
+    out = format_filename("%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?", tokens)
+    assert out == "Raiden - Infection (E-Sassin Remix)"
+
+
+def test_optional_section_collapses_when_any_token_missing():
+    tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection", REMIXER="")
+    out = format_filename("%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?", tokens)
+    assert out == "Raiden - Infection"
+
+
+def test_nested_optional_section_collapse_preserves_parent():
+    # Exact example from the spec: empty ALBUMARTIST must NOT prevent the
+    # outer section from rendering.
+    fmt = "[[%ALBUMARTIST% - ]? %ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    tokens = _simple_tokens(
+        ALBUMARTIST="", ALBUM="Guide", TRACKNUMBER="7",
+        ARTIST="Raiden", TITLE="Infection",
+    )
+    out = format_filename(fmt, tokens)
+    # Outer present because ALBUM and TRACKNUMBER are both present; inner
+    # collapses silently.
+    assert out == " Guide - 7 Raiden - Infection"
+
+
+def test_nested_optional_section_fully_present():
+    fmt = "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    tokens = _simple_tokens(
+        ALBUMARTIST="Dieselboy", ALBUM="Guide", TRACKNUMBER="7",
+        ARTIST="Raiden", TITLE="Infection",
+    )
+    out = format_filename(fmt, tokens)
+    assert out == "Dieselboy - Guide - 7 Raiden - Infection"
+
+
+def test_nested_optional_outer_collapses_when_direct_token_missing():
+    fmt = "[[%ALBUMARTIST% - ]?%ALBUM% - %TRACKNUMBER%]? %ARTIST% - %TITLE%"
+    tokens = _simple_tokens(
+        ALBUMARTIST="Dieselboy", ALBUM="", TRACKNUMBER="7",
+        ARTIST="Raiden", TITLE="Infection",
+    )
+    out = format_filename(fmt, tokens)
+    # ALBUM empty -> outer collapses entirely.
+    assert out == " Raiden - Infection"
+
+
+def test_unterminated_optional_raises():
+    try:
+        format_filename("[%ARTIST% - %TITLE%", _simple_tokens(ARTIST="x", TITLE="y"))
+    except FormatParseError:
+        return
+    raise AssertionError("Expected FormatParseError")
+
+
+def test_literal_bracket_without_question_mark():
+    tokens = _simple_tokens(ARTIST="Raiden")
+    # A bare ']' at the top level is a literal.
+    assert format_filename("%ARTIST%]", tokens) == "Raiden]"
+
+
+def test_literal_percent():
+    tokens = _simple_tokens(ARTIST="Raiden")
+    # A '%' not followed by a valid token is a literal.
+    assert format_filename("100%% - %ARTIST%", tokens) == "100%% - Raiden"
+
+
+def test_sanitize_filename_strips_path_separators():
+    assert sanitize_filename("foo/bar") == "foo_bar"
+    assert sanitize_filename("foo\\bar") == "foo_bar"
+
+
+def test_sanitize_filename_strips_reserved_chars():
+    assert sanitize_filename('a:b*c?d"e<f>g|h') == "a_b_c_d_e_f_g_h"
+
+
+def test_sanitize_filename_collapses_whitespace():
+    assert sanitize_filename("foo    bar\n\tbaz") == "foo bar baz"
+
+
+def test_sanitize_filename_trims_dots_and_underscores():
+    assert sanitize_filename("...hello...") == "hello"
+    assert sanitize_filename("  ___ hello ___  ") == "hello"
+
+
+def test_sanitize_filename_empty_input():
+    assert sanitize_filename("") == ""
+    assert sanitize_filename("...") == ""
+    assert sanitize_filename("///") == ""
+
+
+def test_build_token_map_from_dict_uses_uppercase_keys():
+    tokens = build_token_map_from_dict(SAMPLE_RENAME_METADATA)
+    assert tokens["ARTIST"] == "Raiden"
+    assert tokens["TITLE"] == "Infection"
+    assert tokens["ALBUMARTIST"] == "Dieselboy"
+    assert tokens["REMIXER"] == "E-Sassin"
+    assert tokens["TRACKNUMBER"] == "7"
+    # Missing tags come back as empty strings.
+    assert tokens.get("GROUPING", "x") == ""
+    # Stream info is coerced to plain strings.
+    assert tokens["BITRATE"] == "320000"
+
+
+def test_build_token_map_handles_float_lengths():
+    tokens = build_token_map_from_dict({"length": 342.5})
+    assert tokens["LENGTH"] == "342.5"
+    tokens = build_token_map_from_dict({"length": 342.0})
+    assert tokens["LENGTH"] == "342"
+
+
+def test_list_tokens_by_section_has_both_sections():
+    sections = list_tokens_by_section()
+    assert RENAME_SECTION_TAGS in sections
+    assert RENAME_SECTION_STREAM_INFO in sections
+
+    tag_tokens = {token for token, _desc in sections[RENAME_SECTION_TAGS]}
+    assert "%ARTIST%" in tag_tokens
+    assert "%TITLE%" in tag_tokens
+    assert "%TRACKNUMBER%" in tag_tokens
+
+    # Replaygain keys must not be exposed to the formatter.
+    stream_tokens = {token for token, _desc in sections[RENAME_SECTION_STREAM_INFO]}
+    assert "%BITRATE%" in stream_tokens
+    assert not any("REPLAYGAIN" in t for t in stream_tokens)
+
+
+def test_validate_format_string_reports_parse_errors():
+    ok, msg = validate_format_string("[%ARTIST% - %TITLE%")
+    assert ok is False
+    assert msg
+
+
+def test_validate_format_string_warns_on_unknown_token():
+    ok, msg = validate_format_string("%ARTIST% - %NOTATHING%")
+    assert ok is True
+    assert "NOTATHING" in msg
+
+
+def test_validate_format_string_accepts_valid():
+    ok, msg = validate_format_string("%ARTIST% - %TITLE%")
+    assert ok is True
+    assert msg == ""
+
+
+def test_end_to_end_sample_metadata():
+    tokens = build_token_map_from_dict(SAMPLE_RENAME_METADATA)
+    fmt = "[%TRACKNUMBER:00% - ]?%ARTIST% - %TITLE%[ (%REMIXER% Remix)]?"
+    out = format_filename(fmt, tokens)
+    assert out == "07 - Raiden - Infection (E-Sassin Remix)"

--- a/tests/util/test_rename_formatter.py
+++ b/tests/util/test_rename_formatter.py
@@ -201,9 +201,23 @@ def test_validate_format_string_reports_parse_errors():
     assert msg
 
 
-def test_validate_format_string_warns_on_unknown_token():
+def test_validate_format_string_rejects_unknown_token():
     ok, msg = validate_format_string("%ARTIST% - %NOTATHING%")
-    assert ok is True
+    assert ok is False
+    assert "NOTATHING" in msg
+
+
+def test_validate_format_string_rejects_multiple_unknown_tokens():
+    ok, msg = validate_format_string("%FOO% - %BAR% - %ARTIST%")
+    assert ok is False
+    # Both unknown tokens listed (alphabetized, deduped).
+    assert "BAR" in msg
+    assert "FOO" in msg
+
+
+def test_validate_format_string_rejects_unknown_token_inside_optional():
+    ok, msg = validate_format_string("[%NOTATHING% - ]?%ARTIST%")
+    assert ok is False
     assert "NOTATHING" in msg
 
 

--- a/tests/util/test_rename_formatter.py
+++ b/tests/util/test_rename_formatter.py
@@ -67,6 +67,52 @@ def test_padding_negative_number():
     assert format_filename("%TRACKNUMBER:000%", tokens) == "-003"
 
 
+def test_initialkey_pads_leading_digits_of_camelot_notation():
+    # "7A" with :00 -> "07A". The Camelot special case pads the numeric
+    # prefix while preserving the trailing letter.
+    tokens = {"INITIALKEY": "7A"}
+    assert format_filename("%INITIALKEY:00%", tokens) == "07A"
+
+
+def test_initialkey_leaves_two_digit_camelot_unchanged():
+    tokens = {"INITIALKEY": "11B"}
+    assert format_filename("%INITIALKEY:00%", tokens) == "11B"
+
+
+def test_initialkey_pads_to_requested_width():
+    tokens = {"INITIALKEY": "1A"}
+    assert format_filename("%INITIALKEY:000%", tokens) == "001A"
+
+
+def test_initialkey_without_digits_unchanged():
+    # Traditional notation like "Am" or "C#m" has no leading digits - padding
+    # is a no-op.
+    tokens = {"INITIALKEY": "Am"}
+    assert format_filename("%INITIALKEY:00%", tokens) == "Am"
+
+
+def test_initialkey_empty_value_stays_empty():
+    tokens = {"INITIALKEY": ""}
+    assert format_filename("%INITIALKEY:00%", tokens) == ""
+
+
+def test_initialkey_purely_numeric_value_padded():
+    tokens = {"INITIALKEY": "7"}
+    assert format_filename("%INITIALKEY:00%", tokens) == "07"
+
+
+def test_initialkey_unpadded_token_renders_verbatim():
+    tokens = {"INITIALKEY": "7A"}
+    assert format_filename("%INITIALKEY%", tokens) == "7A"
+
+
+def test_camelot_special_case_does_not_apply_to_other_tokens():
+    # Only INITIALKEY gets the leading-digit pad. Other tokens fall back to
+    # the strict fully-numeric rule, so "2Pac" stays "2Pac" even with :00.
+    tokens = _simple_tokens(ARTIST="2Pac")
+    assert format_filename("%ARTIST:00%", tokens) == "2Pac"
+
+
 def test_optional_section_renders_when_present():
     tokens = _simple_tokens(ARTIST="Raiden", TITLE="Infection",
                             REMIXER="E-Sassin")

--- a/tests/windows/test_rename_presets_pane.py
+++ b/tests/windows/test_rename_presets_pane.py
@@ -1,0 +1,71 @@
+"""Tests for the Rename Presets preferences pane."""
+import pytest
+
+from util.const import IN_GITHUB_RUNNER, RENAME_PRESETS_DEFAULTS
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
+def test_pane_roundtrips_presets_through_settings(qapp, tmp_path, monkeypatch):
+    from models.settings import get_qsettings
+    from PySide6.QtCore import QSettings
+    from windows.preferences.rename_presets_pane import RenamePresetsPane
+    from windows.rename.setup_dialog import load_presets_from_settings
+
+    # Redirect QSettings to a per-test ini file so we don't pollute real settings.
+    settings_path = tmp_path / "yaamt_test.ini"
+    monkeypatch.setattr(
+        "models.settings.get_qsettings",
+        lambda: QSettings(str(settings_path), QSettings.Format.IniFormat),
+    )
+    # Also ensure the pane's load path uses the same.
+    monkeypatch.setattr(
+        "windows.preferences.rename_presets_pane.load_presets_from_settings",
+        lambda: load_presets_from_settings(),
+    )
+
+    pane = RenamePresetsPane()
+    pane.load_defaults()
+    assert pane._collect_presets() == list(RENAME_PRESETS_DEFAULTS)
+
+    # Append a custom preset and save.
+    pane._add_item("%GENRE% - %ARTIST% - %TITLE%")
+    pane.save_to_settings()
+
+    # Loading again should preserve the extra preset.
+    saved = load_presets_from_settings()
+    assert saved[:-1] == list(RENAME_PRESETS_DEFAULTS)
+    assert saved[-1] == "%GENRE% - %ARTIST% - %TITLE%"
+
+    # Remove via UI path and save -> the list shrinks.
+    pane.list_widget.setCurrentRow(0)
+    pane._on_remove()
+    pane.save_to_settings()
+
+    saved = load_presets_from_settings()
+    assert saved[0] != RENAME_PRESETS_DEFAULTS[0] or len(saved) == len(RENAME_PRESETS_DEFAULTS)
+
+    # Validation always returns OK for this pane.
+    ok, msg = pane.validate()
+    assert ok is True
+    assert msg == ""
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
+def test_pane_move_up_down(qapp):
+    from windows.preferences.rename_presets_pane import RenamePresetsPane
+
+    pane = RenamePresetsPane()
+    pane._populate_list(["a", "b", "c"])
+
+    pane.list_widget.setCurrentRow(0)
+    pane._move(+1)
+    assert [pane.list_widget.item(i).text() for i in range(3)] == ["b", "a", "c"]
+
+    pane.list_widget.setCurrentRow(2)
+    pane._move(-1)
+    assert [pane.list_widget.item(i).text() for i in range(3)] == ["b", "c", "a"]
+
+    # Move past edge is a no-op.
+    pane.list_widget.setCurrentRow(0)
+    pane._move(-1)
+    assert [pane.list_widget.item(i).text() for i in range(3)] == ["b", "c", "a"]

--- a/tests/workers/test_rename_dispatcher.py
+++ b/tests/workers/test_rename_dispatcher.py
@@ -1,0 +1,183 @@
+"""Tests for workers.rename_dispatcher."""
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from util.const import (
+    IN_GITHUB_RUNNER,
+    RENAME_COLLISION_AUTO_DISAMBIGUATE,
+    RENAME_COLLISION_OVERWRITE,
+    RENAME_COLLISION_SKIP,
+)
+
+
+FIXTURE_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fixtures",
+    "metadata",
+)
+
+
+def _find_fixture_file() -> str:
+    for entry in os.listdir(FIXTURE_ROOT):
+        path = os.path.join(FIXTURE_ROOT, entry)
+        if os.path.isfile(path) and entry.lower().endswith((".mp3", ".flac", ".wav")):
+            return path
+    raise RuntimeError(f"No audio fixture files under {FIXTURE_ROOT}")
+
+
+@pytest.fixture
+def tmp_audio_copy():
+    """Copy a fixture audio file to a fresh temp dir and yield its path."""
+    src = _find_fixture_file()
+    tmp_dir = tempfile.mkdtemp(prefix="yaamt_rename_test_")
+    dest = os.path.join(tmp_dir, os.path.basename(src))
+    shutil.copy(src, dest)
+    try:
+        yield dest
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def test_plan_rename_produces_target_path(tmp_audio_copy):
+    from models.media_file import MediaFile
+    from workers.rename_dispatcher import plan_rename
+
+    mf = MediaFile(tmp_audio_copy)
+    task = plan_rename(mf, "%ARTIST% - %TITLE%", RENAME_COLLISION_AUTO_DISAMBIGUATE)
+
+    assert task.extension == os.path.splitext(tmp_audio_copy)[1]
+    assert task.target_path.startswith(os.path.dirname(tmp_audio_copy))
+    # Basename should end with the original extension.
+    assert task.target_path.endswith(task.extension)
+
+
+def test_plan_rename_empty_render_marks_task_unrunnable(tmp_audio_copy):
+    from models.media_file import MediaFile
+    from workers.rename_dispatcher import plan_rename
+
+    mf = MediaFile(tmp_audio_copy)
+    task = plan_rename(mf, "[%NOPE%]?", RENAME_COLLISION_SKIP)
+
+    # Empty render -> empty basename, empty target path.
+    assert task.target_basename == ""
+    assert task.target_path == ""
+
+
+def test_resolve_within_batch_collisions_auto_disambiguate():
+    from workers.rename_dispatcher import (
+        RenameTask, resolve_within_batch_collisions,
+    )
+
+    # Two tasks targeting the same path - second should get " (2)" suffix.
+    t1 = RenameTask(
+        media_file=None, target_basename="same", extension=".mp3",
+        collision_mode=RENAME_COLLISION_AUTO_DISAMBIGUATE,
+        target_path="/tmp/same.mp3",
+    )
+    t2 = RenameTask(
+        media_file=None, target_basename="same", extension=".mp3",
+        collision_mode=RENAME_COLLISION_AUTO_DISAMBIGUATE,
+        target_path="/tmp/same.mp3",
+    )
+    resolve_within_batch_collisions([t1, t2])
+
+    assert t1.target_path == "/tmp/same.mp3"
+    assert t2.target_path == "/tmp/same (2).mp3"
+    assert t2.target_basename == "same (2)"
+
+
+def test_resolve_within_batch_collisions_skip_marks_later_failures():
+    from workers.rename_dispatcher import (
+        RenameTask, resolve_within_batch_collisions,
+    )
+
+    t1 = RenameTask(
+        media_file=None, target_basename="same", extension=".mp3",
+        collision_mode=RENAME_COLLISION_SKIP,
+        target_path="/tmp/same.mp3",
+    )
+    t2 = RenameTask(
+        media_file=None, target_basename="same", extension=".mp3",
+        collision_mode=RENAME_COLLISION_SKIP,
+        target_path="/tmp/same.mp3",
+    )
+    resolve_within_batch_collisions([t1, t2])
+
+    assert t1.result is None
+    assert t2.result is not None
+    assert t2.result.success is False
+    assert "Another file in this batch" in t2.result.error
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt signals require running event loop")
+def test_dispatcher_renames_file_end_to_end(qapp, tmp_audio_copy):
+    from models.media_file import MediaFile
+    from workers.rename_dispatcher import RenameDispatcher
+
+    mf = MediaFile(tmp_audio_copy)
+    dispatcher = RenameDispatcher()
+
+    completed = []
+    dispatcher.analysis_completed.connect(lambda: completed.append(True))
+
+    dispatcher.enqueue([mf], "renamed_%FORMAT%", RENAME_COLLISION_AUTO_DISAMBIGUATE)
+    dispatcher.start()
+
+    # Pump the event loop until completion or timeout.
+    import time
+    from PySide6.QtCore import QCoreApplication
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not completed:
+        QCoreApplication.processEvents()
+        time.sleep(0.01)
+
+    assert completed, "Rename dispatcher did not finish within timeout"
+
+    summary = dispatcher.get_summary()
+    assert summary["total"] == 1
+    assert summary["successful"] == 1
+    assert not summary["failed"]
+
+    # Original file should no longer exist; target file should exist.
+    assert not os.path.exists(tmp_audio_copy)
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt signals require running event loop")
+def test_dispatcher_skip_mode_reports_existing_target(qapp, tmp_audio_copy):
+    from models.media_file import MediaFile
+    from workers.rename_dispatcher import RenameDispatcher
+
+    # Create a file at what will be the target so the rename must collide.
+    directory = os.path.dirname(tmp_audio_copy)
+    mf = MediaFile(tmp_audio_copy)
+
+    # Use a format that targets a fixed name we can pre-create.
+    target_name = "fixed_target"
+    ext = os.path.splitext(tmp_audio_copy)[1]
+    existing_target = os.path.join(directory, target_name + ext)
+    with open(existing_target, "wb") as f:
+        f.write(b"not an audio file")
+
+    dispatcher = RenameDispatcher()
+    completed = []
+    dispatcher.analysis_completed.connect(lambda: completed.append(True))
+
+    dispatcher.enqueue([mf], target_name, RENAME_COLLISION_SKIP)
+    dispatcher.start()
+
+    import time
+    from PySide6.QtCore import QCoreApplication
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not completed:
+        QCoreApplication.processEvents()
+        time.sleep(0.01)
+
+    summary = dispatcher.get_summary()
+    assert summary["successful"] == 0
+    assert len(summary["failed"]) == 1
+    assert "already exists" in summary["failed"][0][1]
+    # Source file still exists because rename was skipped.
+    assert os.path.exists(tmp_audio_copy)

--- a/tests/workers/test_rename_dispatcher.py
+++ b/tests/workers/test_rename_dispatcher.py
@@ -59,7 +59,7 @@ def test_plan_rename_empty_render_marks_task_unrunnable(tmp_audio_copy):
     from workers.rename_dispatcher import plan_rename
 
     mf = MediaFile(tmp_audio_copy)
-    task = plan_rename(mf, "[%NOPE%]?", RENAME_COLLISION_SKIP)
+    task = plan_rename(mf, "<%NOPE%>", RENAME_COLLISION_SKIP)
 
     # Empty render -> empty basename, empty target path.
     assert task.target_basename == ""


### PR DESCRIPTION
## Summary
Implements a complete "Rename files based on metadata" feature that allows users to bulk-rename media files using customizable format strings with metadata tokens. The feature includes a setup dialog for composing format strings, live preview, collision handling modes, and persistent preset management.

## Key Changes

### Core Rename Infrastructure
- **`src/workers/rename_dispatcher.py`** (new): Dispatcher for executing rename operations serially in a thread pool, shaped like `AnalyzerDispatcher` for UI reuse via duck typing. Includes:
  - `RenameTask` and `RenameResult` dataclasses for task management
  - `_RenameWorker` QRunnable for executing individual file renames
  - `plan_rename()` to compute target paths from format strings
  - `resolve_within_batch_collisions()` to handle within-batch filename collisions (auto-disambiguate, skip, overwrite modes)

### Format String Engine
- **`src/util/rename_formatter.py`** (new): Parser and formatter for the rename format language supporting:
  - Token substitution (`%ARTIST%`, `%TITLE%`, etc.)
  - Numeric padding (`%TRACKNUMBER:00%`)
  - Optional sections (`[text %TOKEN%]?` that collapse if tokens are empty)
  - Nested optional sections with proper collapse semantics
  - Filename sanitization (removes path separators, Windows-reserved chars, control chars)
  - Token mapping from `MediaFile` objects and sample dictionaries

### User Interface
- **`src/windows/rename/setup_dialog.py`** (new): Main configuration dialog featuring:
  - Format string text editor with preset dropdown
  - Live single-line example preview (updates on keystroke)
  - Preview table showing current vs. new filenames (capped at 12 rows)
  - Collision mode selector (auto-disambiguate/skip/overwrite)
  - Token reference button linking to token documentation

- **`src/windows/rename/token_reference_dialog.py`** (new): Read-only reference table of all available tokens grouped by section (Tags, Stream Info), with copyable rows

- **`src/windows/preferences/rename_presets_pane.py`** (new): Preferences pane for managing format-string presets with add/edit/remove/reorder/reset functionality

### Integration
- **`src/windows/main_window.py`** (modified): 
  - Added "Metadata" submenu to File menu and context menu
  - Added "Rename files based on metadata..." action
  - Integrated rename dispatcher with progress/summary dialogs
  - File list refresh after rename completion

- **`src/windows/analyzer/progress_dialog.py`** (modified): Generalized to support both analyzer and rename workflows via optional dispatcher parameter and customizable labels

- **`src/windows/analyzer/summary_dialog.py`** (modified): Generalized to display results for both analysis and rename operations with customizable success verb

- **`src/util/const.py`** (modified): Added constants for:
  - Rename collision modes (`RENAME_COLLISION_AUTO_DISAMBIGUATE`, `RENAME_COLLISION_SKIP`, `RENAME_COLLISION_OVERWRITE`)
  - Formatting tags and sections (`ALL_FORMATTING_TAGS`, `RENAME_SECTION_TAGS`, `RENAME_SECTION_STREAM_INFO`)
  - Extra rename-useful tags (`EXTRA_RENAME_TAGS`: remixer, label, publisher, etc.)
  - Stream info labels for rename context
  - Settings keys for presets and collision mode persistence
  - Sample metadata for preview rendering

### Testing
- **`tests/util/test_rename_formatter.py`** (new): Comprehensive tests for format string parsing, token substitution, padding, optional sections, and sanitization
- **`tests/workers/test_rename_dispatcher.py`** (new): Tests for task planning, collision resolution, and end-to-end rename operations
- **`tests/windows/test_rename_presets_pane.py`** (new): Tests for preset persistence through QSettings

## Notable Implementation Details

- **Duck typing for UI reuse**: The `R

https://claude.ai/code/session_01UuHhzCSRRtBtWBmXBgonhD