### PR TITLE
Fix Open Key notation mapping to match published standard

### DIFF
--- a/src/providers/metadata/tag_transformers/musical_key_formatter.py
+++ b/src/providers/metadata/tag_transformers/musical_key_formatter.py
@@ -12,7 +12,7 @@ from util.const import (
     KEY_INITIAL_KEY, KEY_NOTATION_FORMAT_DEFAULT, SETTINGS_KEY_NOTATION_FORMAT,
 )
 from util.logging import log
-from util.diatonic_key import CAMELOT_MAP, OPEN_KEY_MAP, NOTE_TO_PITCH, parse_key, format_key, NotationFormat
+from util.diatonic_key import parse_key, format_key, NotationFormat
 from .base import TransformerBase
 
 class MusicalKeyFormatter(TransformerBase):
@@ -23,7 +23,7 @@ class MusicalKeyFormatter(TransformerBase):
     - "standard_abbrev": Cmin, Amaj, Dbmin, F#maj
     - "standard_single": Cm, A, Dbm, F#
     - "camelot": 6A, 8B, 2A, 7B
-    - "open_key": 6m, 8d, 2m, 7d
+    - "open_key": 11m, 1d, 7m, 12d
 
     Reads preference from the ``SETTINGS_KEY_NOTATION_FORMAT`` QSettings key.
     Default: "standard_abbrev"
@@ -68,10 +68,9 @@ class MusicalKeyFormatter(TransformerBase):
             tag_name: The generic tag name (should be 'key' or 'musical_key')
 
         Returns:
-            Formatted key string
-
-        Raises:
-            ValueError: If the key notation cannot be parsed
+            Formatted key string. If the key notation cannot be parsed, the
+            input rendered as a string is returned unchanged and a warning
+            is logged.
         """
         # Handle empty string
         if value == "" or value is None:
@@ -83,9 +82,8 @@ class MusicalKeyFormatter(TransformerBase):
         # Parse the key
         parsed = parse_key(key_str)
         if parsed is None:
-            # raise ValueError(f"Invalid musical key notation: {key_str}")
             log.warning(f"Invalid musical key notation: '{key_str}'. Ignoring...")
-            return value
+            return key_str
 
         pitch_class, is_minor = parsed
 

--- a/src/util/diatonic_key.py
+++ b/src/util/diatonic_key.py
@@ -39,31 +39,31 @@ CAMELOT_MAP = {
 # Open Key mapping: (pitch_class, is_minor) -> Open Key notation
 OPEN_KEY_MAP = {
     # Minor keys (m suffix)
-    (0, True): "5m",   # C minor
-    (1, True): "12m",  # C♯/D♭ minor
-    (2, True): "7m",   # D minor
-    (3, True): "2m",   # D♯/E♭ minor
-    (4, True): "9m",   # E minor
-    (5, True): "4m",   # F minor
-    (6, True): "11m",  # F♯/G♭ minor
-    (7, True): "6m",   # G minor
-    (8, True): "1m",   # G♯/A♭ minor
-    (9, True): "8m",   # A minor
-    (10, True): "3m",  # A♯/B♭ minor
-    (11, True): "10m", # B minor
+    (0, True): "10m",  # C minor
+    (1, True): "5m",   # C♯/D♭ minor
+    (2, True): "12m",  # D minor
+    (3, True): "7m",   # D♯/E♭ minor
+    (4, True): "2m",   # E minor
+    (5, True): "9m",   # F minor
+    (6, True): "4m",   # F♯/G♭ minor
+    (7, True): "11m",  # G minor
+    (8, True): "6m",   # G♯/A♭ minor
+    (9, True): "1m",   # A minor
+    (10, True): "8m",  # A♯/B♭ minor
+    (11, True): "3m",  # B minor
     # Major keys (d suffix)
-    (0, False): "8d",  # C major
-    (1, False): "3d",  # C♯/D♭ major
-    (2, False): "10d", # D major
-    (3, False): "5d",  # D♯/E♭ major
-    (4, False): "12d", # E major
-    (5, False): "7d",  # F major
-    (6, False): "2d",  # F♯/G♭ major
-    (7, False): "9d",  # G major
-    (8, False): "4d",  # G♯/A♭ major
-    (9, False): "11d", # A major
-    (10, False): "6d", # A♯/B♭ major
-    (11, False): "1d", # B major
+    (0, False): "1d",   # C major
+    (1, False): "8d",   # C♯/D♭ major
+    (2, False): "3d",   # D major
+    (3, False): "10d",  # D♯/E♭ major
+    (4, False): "5d",   # E major
+    (5, False): "12d",  # F major
+    (6, False): "7d",   # F♯/G♭ major
+    (7, False): "2d",   # G major
+    (8, False): "9d",   # G♯/A♭ major
+    (9, False): "4d",   # A major
+    (10, False): "11d", # A♯/B♭ major
+    (11, False): "6d",  # B major
 }
 
 # Note name to pitch class mapping -- accidental will modify these numbers +1/-1

--- a/tests/providers/metadata/test_tag_transformers.py
+++ b/tests/providers/metadata/test_tag_transformers.py
@@ -369,6 +369,15 @@ class TestMusicalKeyFormatter:
         assert formatter.transform("Cmin", 'key') == "5A"  # standard_abbrev -> Camelot
         assert formatter.transform("Cm", 'key') == "5A"  # standard_single -> Camelot
 
+    def test_transform_converts_to_open_key(self, mock_settings):
+        """Test conversion to Open Key notation."""
+        mock_settings.setValue("Analyzers/CategoryOptions/key/notation_format", "open_key")
+        formatter = MusicalKeyFormatter(mock_settings)
+        assert formatter.transform("Cmaj", 'key') == "1d"   # C major -> 1d
+        assert formatter.transform("Amin", 'key') == "1m"   # A minor -> 1m
+        assert formatter.transform("Cmin", 'key') == "10m"  # C minor -> 10m
+        assert formatter.transform("5A", 'key') == "10m"    # Camelot C minor -> Open Key 10m
+
     def test_transform_handles_various_input_formats(self, mock_settings):
         """Test that transform can parse various input formats."""
         mock_settings.setValue("Analyzers/CategoryOptions/key/notation_format", "standard_abbrev")
@@ -398,6 +407,13 @@ class TestMusicalKeyFormatter:
         # Invalid keys should return the original value with a warning logged
         assert formatter.transform("invalid", 'key') == "invalid"
         assert formatter.transform("Z minor", 'key') == "Z minor"
+
+    def test_invalid_non_string_key_returns_string(self, mock_settings):
+        """Test that unparseable non-string values are returned as strings."""
+        formatter = MusicalKeyFormatter(mock_settings)
+        result = formatter.transform(123, 'key')
+        assert result == "123"
+        assert isinstance(result, str)
 
     def test_applicable_tags(self):
         """Test that MusicalKeyFormatter declares applicable tags."""

--- a/tests/providers/metadata/test_tag_transformers.py
+++ b/tests/providers/metadata/test_tag_transformers.py
@@ -383,7 +383,8 @@ class TestMusicalKeyFormatter:
         assert formatter.transform("5A", 'key') == "Cmin"
 
         # Open Key format
-        assert formatter.transform("5m", 'key') == "Cmin"
+        assert formatter.transform("10m", 'key') == "Cmin"
+        assert formatter.transform("5m", 'key') == "C#min"  # Open Key 5m is C#/Db minor, not C minor
 
     def test_empty_key(self, mock_settings):
         """Test handling of empty key value."""

--- a/tests/util/test_diatonic_key.py
+++ b/tests/util/test_diatonic_key.py
@@ -139,19 +139,33 @@ class TestParseKeyOpenKeyNotation:
 
     def test_parse_open_key_minor_keys(self):
         """Test parsing Open Key minor keys (m suffix)."""
-        assert parse_key("5m") == (0, True)   # C minor
-        assert parse_key("12m") == (1, True)  # C#/Db minor
-        assert parse_key("7m") == (2, True)   # D minor
-        assert parse_key("8m") == (9, True)   # A minor
-        assert parse_key("10m") == (11, True) # B minor
+        assert parse_key("10m") == (0, True)  # C minor
+        assert parse_key("5m") == (1, True)   # C#/Db minor
+        assert parse_key("12m") == (2, True)  # D minor
+        assert parse_key("7m") == (3, True)   # D#/Eb minor
+        assert parse_key("2m") == (4, True)   # E minor
+        assert parse_key("9m") == (5, True)   # F minor
+        assert parse_key("4m") == (6, True)   # F#/Gb minor
+        assert parse_key("11m") == (7, True)  # G minor
+        assert parse_key("6m") == (8, True)   # G#/Ab minor
+        assert parse_key("1m") == (9, True)   # A minor
+        assert parse_key("8m") == (10, True)  # A#/Bb minor
+        assert parse_key("3m") == (11, True)  # B minor
 
     def test_parse_open_key_major_keys(self):
         """Test parsing Open Key major keys (d suffix)."""
-        assert parse_key("8d") == (0, False)  # C major
-        assert parse_key("3d") == (1, False)  # C#/Db major
-        assert parse_key("10d") == (2, False) # D major
-        assert parse_key("11d") == (9, False) # A major
-        assert parse_key("1d") == (11, False) # B major
+        assert parse_key("1d") == (0, False)   # C major
+        assert parse_key("8d") == (1, False)   # C#/Db major
+        assert parse_key("3d") == (2, False)   # D major
+        assert parse_key("10d") == (3, False)  # D#/Eb major
+        assert parse_key("5d") == (4, False)   # E major
+        assert parse_key("12d") == (5, False)  # F major
+        assert parse_key("7d") == (6, False)   # F#/Gb major
+        assert parse_key("2d") == (7, False)   # G major
+        assert parse_key("9d") == (8, False)   # G#/Ab major
+        assert parse_key("4d") == (9, False)   # A major
+        assert parse_key("11d") == (10, False) # A#/Bb major
+        assert parse_key("6d") == (11, False)  # B major
 
     def test_parse_open_key_all_positions(self):
         """Test that all 24 Open Key positions parse correctly."""
@@ -224,10 +238,32 @@ class TestFormatKey:
 
     def test_format_open_key(self):
         """Test formatting to Open Key notation."""
-        assert format_key(0, True, NotationFormat.OpenKey) == "5m"   # C minor
-        assert format_key(0, False, NotationFormat.OpenKey) == "8d"  # C major
-        assert format_key(9, True, NotationFormat.OpenKey) == "8m"   # A minor
-        assert format_key(9, False, NotationFormat.OpenKey) == "11d" # A major
+        # Minor keys
+        assert format_key(0, True, NotationFormat.OpenKey) == "10m"  # C minor
+        assert format_key(1, True, NotationFormat.OpenKey) == "5m"   # C#/Db minor
+        assert format_key(2, True, NotationFormat.OpenKey) == "12m"  # D minor
+        assert format_key(3, True, NotationFormat.OpenKey) == "7m"   # D#/Eb minor
+        assert format_key(4, True, NotationFormat.OpenKey) == "2m"   # E minor
+        assert format_key(5, True, NotationFormat.OpenKey) == "9m"   # F minor
+        assert format_key(6, True, NotationFormat.OpenKey) == "4m"   # F#/Gb minor
+        assert format_key(7, True, NotationFormat.OpenKey) == "11m"  # G minor
+        assert format_key(8, True, NotationFormat.OpenKey) == "6m"   # G#/Ab minor
+        assert format_key(9, True, NotationFormat.OpenKey) == "1m"   # A minor
+        assert format_key(10, True, NotationFormat.OpenKey) == "8m"  # A#/Bb minor
+        assert format_key(11, True, NotationFormat.OpenKey) == "3m"  # B minor
+        # Major keys
+        assert format_key(0, False, NotationFormat.OpenKey) == "1d"   # C major
+        assert format_key(1, False, NotationFormat.OpenKey) == "8d"   # C#/Db major
+        assert format_key(2, False, NotationFormat.OpenKey) == "3d"   # D major
+        assert format_key(3, False, NotationFormat.OpenKey) == "10d"  # D#/Eb major
+        assert format_key(4, False, NotationFormat.OpenKey) == "5d"   # E major
+        assert format_key(5, False, NotationFormat.OpenKey) == "12d"  # F major
+        assert format_key(6, False, NotationFormat.OpenKey) == "7d"   # F#/Gb major
+        assert format_key(7, False, NotationFormat.OpenKey) == "2d"   # G major
+        assert format_key(8, False, NotationFormat.OpenKey) == "9d"   # G#/Ab major
+        assert format_key(9, False, NotationFormat.OpenKey) == "4d"   # A major
+        assert format_key(10, False, NotationFormat.OpenKey) == "11d" # A#/Bb major
+        assert format_key(11, False, NotationFormat.OpenKey) == "6d"  # B major
 
     def test_format_uses_mixed_sharps_flats(self):
         """Test that formatting uses the predetermined sharp/flat choices."""
@@ -352,6 +388,34 @@ class TestMusicTheoryValidation:
             # Next key should be 7 semitones higher (a perfect fifth)
             assert (current + 7) % 12 == next_key, \
                 f"Circle of fifths broken at pitch class {current}"
+
+    def test_open_key_is_rotated_camelot(self):
+        """Test that Open Key is the Camelot wheel with numbers rotated.
+
+        The published relation is open = ((camelot + 4) % 12) + 1, with
+        Camelot A (minor) -> m and Camelot B (major) -> d.
+        Anchor: Camelot 8B (C major) -> Open Key 1d.
+        """
+        for (pitch, is_minor), camelot in CAMELOT_MAP.items():
+            camelot_num = int(camelot[:-1])
+            expected_num = ((camelot_num + 4) % 12) + 1
+            expected_suffix = "m" if is_minor else "d"
+            assert OPEN_KEY_MAP[(pitch, is_minor)] == f"{expected_num}{expected_suffix}", \
+                f"Open Key for pitch={pitch}, minor={is_minor} must be the rotation of Camelot {camelot}"
+
+    def test_open_key_relative_major_minor_pairs(self):
+        """Test that relative major/minor pairs share the same Open Key number.
+
+        For example: 1d = C major and 1m = A minor are relative keys.
+        """
+        for major_pitch in range(12):
+            relative_minor_pitch = (major_pitch + 9) % 12
+            major_open = format_key(major_pitch, False, NotationFormat.OpenKey)
+            minor_open = format_key(relative_minor_pitch, True, NotationFormat.OpenKey)
+
+            assert major_open.endswith("d") and minor_open.endswith("m")
+            assert major_open[:-1] == minor_open[:-1], \
+                f"Relative keys should share Open Key number: {major_open} vs {minor_open}"
 
     def test_pitch_class_mapping(self):
         """Test that NOTE_TO_PITCH mapping is correct."""


### PR DESCRIPTION
## Summary
Corrects the Open Key notation mapping in the diatonic key module to align with the published Open Key standard. The mapping was previously incorrect; it has been updated to use the proper rotation formula: `open_key_number = ((camelot_number + 4) % 12) + 1`.

## Key Changes
- **Updated OPEN_KEY_MAP** in `src/util/diatonic_key.py`: Remapped all 24 pitch/mode combinations to their correct Open Key values. For example:
  - C major: `8d` → `1d`
  - C minor: `5m` → `10m`
  - A minor: `8m` → `1m`
  
- **Expanded test coverage** in `tests/util/test_diatonic_key.py`:
  - Extended `test_parse_open_key_minor_keys()` and `test_parse_open_key_major_keys()` to cover all 12 pitch classes (previously only tested 5 keys)
  - Expanded `test_format_open_key()` to test all 24 key combinations with organized comments
  - Added `test_open_key_is_rotated_camelot()` to verify the mathematical relationship between Camelot and Open Key notations
  - Added `test_open_key_relative_major_minor_pairs()` to ensure relative major/minor pairs share the same Open Key number (e.g., `1d` = C major and `1m` = A minor)

- **Updated tag transformer tests** in `tests/providers/metadata/test_tag_transformers.py`:
  - Added `test_transform_converts_to_open_key()` to verify Open Key conversion in the MusicalKeyFormatter
  - Updated `test_transform_handles_various_input_formats()` to reflect corrected mappings
  - Added `test_invalid_non_string_key_returns_string()` to ensure non-string inputs are handled gracefully

- **Improved error handling** in `src/providers/metadata/tag_transformers/musical_key_formatter.py`:
  - Changed unparseable key handling to return the string representation instead of the original value
  - Updated docstring to clarify that invalid keys are logged and returned as strings
  - Removed unused imports (CAMELOT_MAP, OPEN_KEY_MAP, NOTE_TO_PITCH)

## Implementation Details
The Open Key standard uses a specific rotation of the Camelot wheel. The anchor point is Camelot 8B (C major) = Open Key 1d. This relationship is now properly validated through comprehensive test coverage that verifies both the mathematical formula and the practical key mappings.

https://claude.ai/code/session_011ChyfMEFh41i85H5iqrPkN