### PR TITLE
Implement release/reacquire handshake for playback during file writes

### DIFF
--- a/src/models/edit_manager.py
+++ b/src/models/edit_manager.py
@@ -294,7 +294,12 @@ class EditManager(QObject):
         worker = _CommitWorker(self)
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
-        thread.finished.connect(worker.deleteLater)
+        # The worker is NOT deleteLater'd on the dying thread: that queues
+        # its C++ deletion on the commit thread while the main thread may
+        # concurrently drop the last Python reference, and the two
+        # deletions race (intermittent segfault). Instead both objects are
+        # owned by the Python references below and are released on the
+        # main thread once the OS thread has fully stopped.
         # Identity-checked cleanup: if a newer commit replaced the
         # references before this (queued) cleanup runs, leave them alone.
         thread.finished.connect(lambda t=thread: self._on_commit_thread_finished(t))
@@ -309,6 +314,11 @@ class EditManager(QObject):
         return True
 
     def _on_commit_thread_finished(self, thread: QThread) -> None:
+        # Runs on the main thread (queued) after finished() is emitted.
+        # The OS thread may still be inside its cleanup at that point;
+        # wait() ensures it has fully stopped before the Python references
+        # -- and with them the underlying C++ objects -- are released.
+        thread.wait()
         if self._commit_thread is thread:
             self._commit_thread = None
             self._commit_worker = None

--- a/src/providers/audio/miniaudio_stream.py
+++ b/src/providers/audio/miniaudio_stream.py
@@ -159,8 +159,27 @@ class MiniaudioStream(AudioStreamBase):
             raise ValueError(f"Unsupported sample format: {sample_format}")
         return mapping
 
+    def _close_generator(self) -> None:
+        """
+        Closes the current stream generator, if any.
+
+        generator.close() raises GeneratorExit inside miniaudio's stream
+        generator, which closes the underlying native file handle
+        deterministically instead of leaving it to garbage collection.
+        """
+        generator = getattr(self, 'stream_generator', None)
+        if generator is None:
+            return
+        try:
+            generator.close()
+        except Exception as e:
+            log.warning("Error closing stream generator for '%s': %s",
+                        self.file_path, e)
+        self.stream_generator = None
+
     def _create_memory_stream(self, seek_frame: int = 0) -> None:
         """Creates (or recreates) a memory-based stream generator."""
+        self._close_generator()
         self.stream_generator = miniaudio.stream_memory(
             self._file_data,
             output_format=self._stream_output_format,
@@ -261,6 +280,7 @@ class MiniaudioStream(AudioStreamBase):
         if self._memory_mode:
             self._create_memory_stream(seek_frame=frame_offset)
         else:
+            self._close_generator()
             self.stream_generator = miniaudio.stream_file(
                 self._resolved_path,
                 output_format=self._stream_output_format,
@@ -278,10 +298,7 @@ class MiniaudioStream(AudioStreamBase):
         Closes the audio stream and releases any associated resources.
         """
         if not self._is_closed:
-            # The miniaudio stream generator doesn't have an explicit close method
-            # in the same way a file object does. It's cleaned up by garbage collection.
-            # We can mark it as closed and set references to None.
-            self.stream_generator = None
+            self._close_generator()
             self.info = None
             self._file_data = None
             self._is_closed = True

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1146,6 +1146,16 @@ class MainWindow(QMainWindow):
         dispatcher = RenameDispatcher(self)
         dispatcher.enqueue(media_files, format_string, collision_mode)
 
+        # If the currently playing file is part of the batch, pause
+        # playback for the batch's duration; the completion handler below
+        # resumes it at the file's new location (analysis_completed fires
+        # on both normal completion and cancel). Connected before the
+        # refresh so playback is repointed before the list reloads.
+        self.playback_coordinator.begin_rename_batch(media_files)
+        dispatcher.analysis_completed.connect(
+            self.playback_coordinator.end_rename_batch
+        )
+
         # Immediate post-completion refresh (before summary dialog shows).
         dispatcher.analysis_completed.connect(
             lambda: self._refresh_after_batch(media_files)
@@ -1166,6 +1176,10 @@ class MainWindow(QMainWindow):
 
         dispatcher.start()
         result = progress_dialog.exec()
+
+        # Safety net (idempotent): if the dialog exited without the batch
+        # emitting analysis_completed, playback must not stay released.
+        self.playback_coordinator.end_rename_batch()
 
         if result == QDialog.DialogCode.Accepted:
             summary_dialog = AnalyzerSummaryDialog(
@@ -1744,9 +1758,10 @@ class MainWindow(QMainWindow):
         """
         log.debug("Cleaning up playback resources")
 
-        # Stop any active playback
-        if self.playback_worker.state != "stopped":
-            self.playback_worker.stop()
+        # Stop any active playback. Called unconditionally: during a
+        # release window the state is already STOPPED but a pending
+        # post-write reacquire must still be cancelled.
+        self.playback_worker.stop()
 
         # Disconnect signals to prevent callbacks to destroyed objects
         try:

--- a/src/workers/gui/playback_coordinator.py
+++ b/src/workers/gui/playback_coordinator.py
@@ -3,19 +3,21 @@ import threading
 
 from PySide6.QtCore import QObject, Signal
 
+from models.media_file import MediaFile
 from util.logging import log
 from workers.gui.playback_worker import PlaybackWorker
 
 
 class PlaybackCoordinator(QObject):
     """
-    Coordinates file access between EditManager (save thread) and
-    PlaybackWorker (playback thread).
+    Coordinates file access between components that write to files
+    (EditManager's save thread, the rename flow) and PlaybackWorker
+    (playback thread).
 
-    Before saving a file that is currently playing, the coordinator asks
-    PlaybackWorker to release the file lock (pause + close stream), waits
-    for confirmation, and after the save signals PlaybackWorker to reopen
-    and resume from the saved position.
+    Before a file that is currently playing is written to or renamed, the
+    coordinator asks PlaybackWorker to release it (pause + close stream),
+    waits for confirmation, and afterwards signals PlaybackWorker to
+    reopen and resume from the saved position.
     """
 
     request_release = Signal(str, object)   # file_path, threading.Event
@@ -27,6 +29,11 @@ class PlaybackCoordinator(QObject):
         super().__init__()
         self._playback_worker = playback_worker
         self._released_file_path: str | None = None
+        # The batch source whose file is released while a rename batch
+        # runs. The rename dispatcher repoints this instance in place, so
+        # by end_rename_batch() its file_path is wherever the file
+        # actually ended up (renamed, restored, or unchanged).
+        self._rename_media_file: MediaFile | None = None
 
         self.request_release.connect(playback_worker.release_for_write)
         self.request_reacquire.connect(playback_worker.reacquire_after_write)
@@ -34,11 +41,31 @@ class PlaybackCoordinator(QObject):
     def _normalize(self, file_path: str) -> str:
         return os.path.normcase(os.path.abspath(file_path))
 
+    def _release_and_wait(self, file_path: str) -> None:
+        """Asks PlaybackWorker to release file_path and blocks until it has."""
+        event = threading.Event()
+        self.request_release.emit(file_path, event)
+
+        if not event.wait(timeout=self.RELEASE_TIMEOUT_SECONDS):
+            log.warning(
+                f"PlaybackCoordinator: timed out waiting for playback to release {file_path}. "
+                f"The write will proceed but may fail with a permission error."
+            )
+
     def acquire_file(self, file_path: str) -> None:
         """
         Called from the save thread before writing to a file.
         If PlaybackWorker has this file open, blocks until the file is released.
         """
+        if self._rename_media_file is not None:
+            # A rename batch already holds the playback release, so the
+            # playing file is closed and the save can proceed as-is.
+            log.warning(
+                f"PlaybackCoordinator: save of {file_path} requested while a "
+                f"rename batch holds the playback release; proceeding."
+            )
+            return
+
         normalized = self._normalize(file_path)
 
         current = self._playback_worker.current_file
@@ -47,15 +74,8 @@ class PlaybackCoordinator(QObject):
 
         log.info(f"PlaybackCoordinator: acquiring file for write: {file_path}")
 
-        event = threading.Event()
         self._released_file_path = normalized
-        self.request_release.emit(file_path, event)
-
-        if not event.wait(timeout=self.RELEASE_TIMEOUT_SECONDS):
-            log.warning(
-                f"PlaybackCoordinator: timed out waiting for playback to release {file_path}. "
-                f"Save will proceed but may fail with a permission error."
-            )
+        self._release_and_wait(file_path)
 
     def release_file(self, file_path: str) -> None:
         """
@@ -68,3 +88,47 @@ class PlaybackCoordinator(QObject):
             log.info(f"PlaybackCoordinator: releasing file after write: {file_path}")
             self._released_file_path = None
             self.request_reacquire.emit(None)
+
+    def begin_rename_batch(self, media_files: list[MediaFile]) -> None:
+        """
+        Called on the main thread before a rename batch starts. If the
+        currently playing file is one of the batch's sources, releases it
+        for the duration of the batch.
+
+        Rename batches run under a modal progress dialog, so no
+        user-driven save or second batch can start concurrently -- no
+        locking is needed around the rename state.
+        """
+        current = self._playback_worker.current_file
+        if current is None:
+            return
+
+        normalized_current = self._normalize(current)
+        for media_file in media_files:
+            if self._normalize(media_file.file_path) == normalized_current:
+                log.info(
+                    f"PlaybackCoordinator: releasing {current} for rename batch"
+                )
+                self._rename_media_file = media_file
+                self._release_and_wait(media_file.file_path)
+                return
+
+    def end_rename_batch(self) -> None:
+        """
+        Called on the main thread when a rename batch completes or is
+        cancelled. Idempotent. Resumes playback at wherever the released
+        file's MediaFile instance points now: the rename dispatcher
+        repoints it in place on success and on failure/restore alike, so
+        no path computation is needed here. The playback panel picks up
+        the (possibly new) file name from the resulting playback_started.
+        """
+        media_file = self._rename_media_file
+        if media_file is None:
+            return
+
+        self._rename_media_file = None
+        log.info(
+            f"PlaybackCoordinator: rename batch done; "
+            f"reacquiring {media_file.file_path}"
+        )
+        self.request_reacquire.emit(media_file.file_path)

--- a/src/workers/gui/playback_coordinator.py
+++ b/src/workers/gui/playback_coordinator.py
@@ -19,7 +19,7 @@ class PlaybackCoordinator(QObject):
     """
 
     request_release = Signal(str, object)   # file_path, threading.Event
-    request_reacquire = Signal()
+    request_reacquire = Signal(object)      # new file path (str) or None
 
     RELEASE_TIMEOUT_SECONDS = 10.0
 
@@ -67,4 +67,4 @@ class PlaybackCoordinator(QObject):
         if self._released_file_path == normalized:
             log.info(f"PlaybackCoordinator: releasing file after write: {file_path}")
             self._released_file_path = None
-            self.request_reacquire.emit()
+            self.request_reacquire.emit(None)

--- a/src/workers/gui/playback_worker.py
+++ b/src/workers/gui/playback_worker.py
@@ -32,7 +32,6 @@ class PlaybackWorker(QObject):
     playback_paused = Signal(str, float)
     playback_resumed = Signal(str, float)
     error_occurred = Signal(str)
-    file_released = Signal()               # emitted after file lock released for writing
 
     def __init__(self):
         super().__init__()
@@ -245,17 +244,35 @@ class PlaybackWorker(QObject):
             # The generator will resume outputting audio data
             self.playback_resumed.emit(self.current_file, self.duration)
 
+    def _clear_release_state(self) -> None:
+        """Forgets any pending post-write reacquire."""
+        self._release_file_path = None
+        self._release_saved_position = 0.0
+        self._release_was_playing = False
+
     @Slot()
     def stop(self):
         """
         Stop the current playback and clean up resources.
+
+        Also honors a Stop issued while the file is temporarily released
+        for a write: state is already STOPPED then, but the pending
+        reacquire must be cancelled so the file is not resurrected when
+        the write completes.
         """
+        pending_release = self._release_file_path is not None
+        self._clear_release_state()
+        self.current_file = None
+
         if self.state != STOPPED:
             self.state = STOPPED
-            self._release_file_path = None  # Cancel any pending reacquire
             self.timer.stop()
             self.playback_stopped.emit()
             self.cleanup()
+        elif pending_release:
+            # Released for a write: device and stream are already closed,
+            # only the UI needs to hear about the stop.
+            self.playback_stopped.emit()
 
     @Slot(float)
     def seek(self, position_seconds: float):
@@ -307,7 +324,11 @@ class PlaybackWorker(QObject):
             if self.current_file else None
         )
 
-        if normalized_current != normalized_request:
+        if (normalized_current != normalized_request
+                or self.state == STOPPED
+                or self.audio_stream is None):
+            # Not playing this file (or nothing is actually open) --
+            # there is no lock to release and nothing to resume later.
             event.set()
             return
 
@@ -330,26 +351,31 @@ class PlaybackWorker(QObject):
         log.debug(f"File released (was_playing={self._release_was_playing}, "
                    f"position={self._release_saved_position:.2f}s)")
 
-        self.file_released.emit()
+        # Keep the panel truthful during the write: show the interruption
+        # as a pause with the position frozen. While released, Play is a
+        # no-op -- accepted: the window is milliseconds for a metadata
+        # save, and rename batches run under a modal progress dialog.
+        self.playback_paused.emit(self._release_file_path, self.duration)
         event.set()
 
-    @Slot()
-    def reacquire_after_write(self) -> None:
+    @Slot(object)
+    def reacquire_after_write(self, new_path: str | None = None) -> None:
         """
         Reopen and resume playback of a file that was temporarily released for writing.
         Called via signal from PlaybackCoordinator (executes on the playback thread).
+
+        Args:
+            new_path: Where the file now lives, if it was renamed while
+                released. None means it is still at its original path.
         """
         if self._release_file_path is None:
             return  # Nothing to reacquire (user stopped playback during save)
 
-        file_path = self._release_file_path
+        file_path = new_path or self._release_file_path
         saved_position = self._release_saved_position
         was_playing = self._release_was_playing
 
-        # Clear release state before reacquiring
-        self._release_file_path = None
-        self._release_saved_position = 0.0
-        self._release_was_playing = False
+        self._clear_release_state()
 
         log.info(f"Reacquiring file after write: {file_path} at position {saved_position:.2f}s")
 

--- a/tests/providers/audio/test_miniaudio_stream_release.py
+++ b/tests/providers/audio/test_miniaudio_stream_release.py
@@ -1,0 +1,100 @@
+"""
+Tests that MiniaudioStream releases its underlying file resources
+deterministically on close() and seek(), rather than relying on garbage
+collection. This matters when another component (metadata save, rename)
+needs the file to be genuinely closed before touching it on disk.
+"""
+
+import os
+import shutil
+import sys
+
+import pytest
+
+from providers.audio.miniaudio_stream import MiniaudioStream
+from util.const import PROJECT_ROOT
+
+FIXTURE_AUDIO_FILE = os.path.join(
+    PROJECT_ROOT, 'tests', 'fixtures', 'metadata', 'sample_dtmf_original.flac'
+)
+
+
+class _GeneratorRecorder:
+    """Wraps a stream generator and records whether close() was called."""
+
+    def __init__(self, generator):
+        self._generator = generator
+        self.closed = False
+
+    def send(self, value):
+        return self._generator.send(value)
+
+    def close(self):
+        self.closed = True
+        self._generator.close()
+
+
+@pytest.fixture
+def tmp_audio_file(tmp_path):
+    """A throwaway copy of a fixture audio file (never touch the original)."""
+    dest = tmp_path / os.path.basename(FIXTURE_AUDIO_FILE)
+    shutil.copyfile(FIXTURE_AUDIO_FILE, dest)
+    return str(dest)
+
+
+def _wrap_generator(stream: MiniaudioStream) -> _GeneratorRecorder:
+    recorder = _GeneratorRecorder(stream.stream_generator)
+    stream.stream_generator = recorder
+    return recorder
+
+
+def test_close_closes_generator(tmp_audio_file):
+    stream = MiniaudioStream(tmp_audio_file)
+    recorder = _wrap_generator(stream)
+
+    stream.close()
+
+    assert recorder.closed
+    assert stream.stream_generator is None
+
+
+def test_seek_closes_previous_generator(tmp_audio_file):
+    stream = MiniaudioStream(tmp_audio_file)
+    try:
+        recorder = _wrap_generator(stream)
+
+        stream.seek(0)
+
+        assert recorder.closed
+        # The replacement generator must still be readable.
+        data = stream.read(512)
+        assert len(data) > 0
+    finally:
+        stream.close()
+
+
+def test_close_is_idempotent(tmp_audio_file):
+    stream = MiniaudioStream(tmp_audio_file)
+    stream.close()
+    stream.close()  # Must not raise.
+
+
+@pytest.mark.skipif(sys.platform != 'linux',
+                    reason="/proc/self/fd is Linux-specific")
+def test_close_releases_os_file_handle(tmp_audio_file):
+    def open_fd_count(path: str) -> int:
+        count = 0
+        for fd in os.listdir('/proc/self/fd'):
+            try:
+                if os.readlink(f'/proc/self/fd/{fd}') == path:
+                    count += 1
+            except OSError:
+                continue
+        return count
+
+    stream = MiniaudioStream(tmp_audio_file)
+    assert open_fd_count(tmp_audio_file) >= 1
+
+    stream.close()
+
+    assert open_fd_count(tmp_audio_file) == 0

--- a/tests/workers/gui/conftest.py
+++ b/tests/workers/gui/conftest.py
@@ -1,0 +1,84 @@
+"""
+Shared fixtures for playback-related worker tests: a mocked audio stream,
+a mocked MediaFile, a mocked miniaudio module, and a PlaybackWorker with
+deterministic teardown.
+"""
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import miniaudio
+import pytest
+
+from models.media_file import MediaFile
+from providers.audio.base import AudioStreamBase
+from workers.gui.playback_worker import PlaybackWorker, STOPPED
+
+
+@pytest.fixture
+def mock_audio_stream():
+    """Fixture to create a mock AudioStreamBase instance."""
+    mock_stream = MagicMock(spec=AudioStreamBase)
+    mock_stream.sample_rate = 44100
+    mock_stream.channels_qty = 2
+    mock_stream.sample_width = 2
+    mock_stream.duration_seconds = 10.0
+
+    # Mock the read method to simulate audio data
+    mock_stream.read.return_value = b'\x00' * 1024
+
+    # Keep track of the current position
+    mock_stream.current_frame = 0
+
+    def seek_side_effect(frame_offset):
+        mock_stream.current_frame = frame_offset
+
+    mock_stream.seek.side_effect = seek_side_effect
+
+    def current_position_seconds_side_effect():
+        return mock_stream.current_frame / mock_stream.sample_rate
+
+    type(mock_stream).current_position_seconds = PropertyMock(
+        side_effect=current_position_seconds_side_effect)
+
+    return mock_stream
+
+
+@pytest.fixture
+def mock_media_file(mock_audio_stream):
+    """Fixture to create a mock MediaFile instance."""
+    mock_mf = MagicMock(spec=MediaFile)
+    mock_mf.file_path = "test.mp3"
+    mock_mf.get_audio_stream.return_value = mock_audio_stream
+    return mock_mf
+
+
+@pytest.fixture
+def playback_worker(qapp):
+    """Fixture to create a PlaybackWorker instance."""
+    worker = PlaybackWorker()
+    yield worker
+    # Deterministic teardown: a started position timer must not outlive the
+    # test, or it fires into a destroyed QObject when a later test pumps the
+    # event loop (intermittent segfault/bus error mid-suite).
+    worker.timer.stop()
+    worker.state = STOPPED
+
+
+@pytest.fixture
+def mock_miniaudio():
+    """Fixture to mock miniaudio."""
+    with patch('workers.gui.playback_worker.miniaudio') as mock_ma:
+        # Mock the PlaybackDevice class
+        mock_device = MagicMock()
+        mock_ma.PlaybackDevice.return_value = mock_device
+
+        # Mock SampleFormat enum
+        mock_ma.SampleFormat.UNSIGNED8 = miniaudio.SampleFormat.UNSIGNED8
+        mock_ma.SampleFormat.SIGNED16 = miniaudio.SampleFormat.SIGNED16
+        mock_ma.SampleFormat.SIGNED24 = miniaudio.SampleFormat.SIGNED24
+        mock_ma.SampleFormat.SIGNED32 = miniaudio.SampleFormat.SIGNED32
+
+        yield {
+            'miniaudio_mock': mock_ma,
+            'device_mock': mock_device
+        }

--- a/tests/workers/gui/test_playback_coordinator.py
+++ b/tests/workers/gui/test_playback_coordinator.py
@@ -1,0 +1,170 @@
+"""
+Tests for PlaybackCoordinator: the release/reacquire handshake around
+metadata saves and the batch-level release around file renames.
+
+Worker and coordinator live on the same thread here, so the coordinator's
+signals are delivered synchronously (direct connections) and acquire never
+has to wait on the release event.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.media_file import MediaFile
+from util.const import IN_GITHUB_RUNNER
+from workers.gui.playback_coordinator import PlaybackCoordinator
+from workers.gui.playback_worker import PLAYING, PAUSED, STOPPED
+
+THREE_SECONDS_IN_FRAMES = 44100 * 3
+
+
+@pytest.fixture
+def coordinator(playback_worker):
+    return PlaybackCoordinator(playback_worker)
+
+
+def _make_media_file_mock(file_path: str, mock_audio_stream) -> MagicMock:
+    mf = MagicMock(spec=MediaFile)
+    mf.file_path = file_path
+    mf.get_audio_stream.return_value = mock_audio_stream
+    return mf
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+class TestSaveHandshake:
+
+    def test_acquire_release_roundtrip_resumes_playback(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.total_frames_read = THREE_SECONDS_IN_FRAMES
+
+        coordinator.acquire_file("test.mp3")
+
+        assert playback_worker.state == STOPPED
+        mock_audio_stream.close.assert_called_once()
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=mock_media_file) as media_file_cls:
+            coordinator.release_file("test.mp3")
+
+        media_file_cls.assert_called_once_with("test.mp3")
+        assert playback_worker.state == PLAYING
+        assert playback_worker.total_frames_read == THREE_SECONDS_IN_FRAMES
+
+    def test_acquire_file_not_playing_is_noop(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+
+        coordinator.acquire_file("other.mp3")
+
+        assert playback_worker.state == PLAYING
+        mock_audio_stream.close.assert_not_called()
+
+        # And the paired release must not trigger a reacquire.
+        with patch('workers.gui.playback_worker.MediaFile') as media_file_cls:
+            coordinator.release_file("other.mp3")
+        media_file_cls.assert_not_called()
+
+    def test_roundtrip_preserves_paused_state(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.pause()
+
+        coordinator.acquire_file("test.mp3")
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=mock_media_file):
+            coordinator.release_file("test.mp3")
+
+        assert playback_worker.state == PAUSED
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+class TestRenameBatch:
+
+    def test_begin_end_reacquires_at_updated_path(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.total_frames_read = THREE_SECONDS_IN_FRAMES
+
+        coordinator.begin_rename_batch([mock_media_file])
+        assert playback_worker.state == STOPPED
+
+        # The dispatcher repoints the MediaFile instance in place as the
+        # rename completes; the coordinator must follow it.
+        mock_media_file.file_path = "renamed.mp3"
+        renamed_mf = _make_media_file_mock("renamed.mp3", mock_audio_stream)
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=renamed_mf) as media_file_cls:
+            coordinator.end_rename_batch()
+
+        media_file_cls.assert_called_once_with("renamed.mp3")
+        assert playback_worker.state == PLAYING
+        assert playback_worker.current_file == "renamed.mp3"
+        assert playback_worker.total_frames_read == THREE_SECONDS_IN_FRAMES
+
+    def test_begin_with_no_match_is_noop(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+
+        other = _make_media_file_mock("other.mp3", mock_audio_stream)
+        coordinator.begin_rename_batch([other])
+
+        assert playback_worker.state == PLAYING
+
+        with patch('workers.gui.playback_worker.MediaFile') as media_file_cls:
+            coordinator.end_rename_batch()
+        media_file_cls.assert_not_called()
+        assert playback_worker.state == PLAYING
+
+    def test_begin_with_nothing_playing_is_noop(
+            self, coordinator, playback_worker, mock_media_file):
+        coordinator.begin_rename_batch([mock_media_file])
+        coordinator.end_rename_batch()
+        assert playback_worker.state == STOPPED
+
+    def test_end_is_idempotent(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        coordinator.begin_rename_batch([mock_media_file])
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=mock_media_file) as media_file_cls:
+            coordinator.end_rename_batch()
+            coordinator.end_rename_batch()
+
+        media_file_cls.assert_called_once()
+
+    def test_user_stop_during_batch_wins(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        coordinator.begin_rename_batch([mock_media_file])
+
+        playback_worker.stop()
+
+        with patch('workers.gui.playback_worker.MediaFile') as media_file_cls:
+            coordinator.end_rename_batch()
+
+        media_file_cls.assert_not_called()
+        assert playback_worker.state == STOPPED
+
+    def test_acquire_during_batch_skips_handshake(
+            self, coordinator, playback_worker, mock_media_file,
+            mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        coordinator.begin_rename_batch([mock_media_file])
+
+        release_spy = MagicMock()
+        coordinator.request_release.connect(release_spy)
+
+        # A save arriving mid-batch must proceed without a second handshake.
+        coordinator.acquire_file("test.mp3")
+        release_spy.assert_not_called()

--- a/tests/workers/gui/test_playback_worker.py
+++ b/tests/workers/gui/test_playback_worker.py
@@ -2,82 +2,16 @@ import threading
 
 import pytest
 import miniaudio
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 from util.const import IN_GITHUB_RUNNER
-from workers.gui.playback_worker import PlaybackWorker, PLAYING, PAUSED, STOPPED
-from providers.audio.base import AudioStreamBase
+from workers.gui.playback_worker import PLAYING, PAUSED, STOPPED
 from providers.audio.format_descriptor import AudioFormatDescriptor
 from models.media_file import MediaFile
 from models.settings import settings
 
-@pytest.fixture
-def mock_audio_stream():
-    """Fixture to create a mock AudioStreamBase instance."""
-    mock_stream = MagicMock(spec=AudioStreamBase)
-    mock_stream.sample_rate = 44100
-    mock_stream.channels_qty = 2
-    mock_stream.sample_width = 2
-    mock_stream.duration_seconds = 10.0
-
-    # Mock the read method to simulate audio data
-    mock_stream.read.return_value = b'\x00' * 1024
-
-    # Keep track of the current position
-    mock_stream.current_frame = 0
-
-    def seek_side_effect(frame_offset):
-        mock_stream.current_frame = frame_offset
-
-    mock_stream.seek.side_effect = seek_side_effect
-
-    def current_position_seconds_side_effect():
-        return mock_stream.current_frame / mock_stream.sample_rate
-
-    type(mock_stream).current_position_seconds = PropertyMock(side_effect=current_position_seconds_side_effect)
-
-    return mock_stream
-
-
-@pytest.fixture
-def mock_media_file(mock_audio_stream):
-    """Fixture to create a mock MediaFile instance."""
-    mock_mf = MagicMock(spec=MediaFile)
-    mock_mf.file_path = "test.mp3"
-    mock_mf.get_audio_stream.return_value = mock_audio_stream
-    return mock_mf
-
-
-@pytest.fixture
-def playback_worker(qapp):
-    """Fixture to create a PlaybackWorker instance."""
-    worker = PlaybackWorker()
-    yield worker
-    # Deterministic teardown: a started position timer must not outlive the
-    # test, or it fires into a destroyed QObject when a later test pumps the
-    # event loop (intermittent segfault/bus error mid-suite).
-    worker.timer.stop()
-    worker.state = STOPPED
-
-
-@pytest.fixture
-def mock_miniaudio():
-    """Fixture to mock miniaudio."""
-    with patch('workers.gui.playback_worker.miniaudio') as mock_ma:
-        # Mock the PlaybackDevice class
-        mock_device = MagicMock()
-        mock_ma.PlaybackDevice.return_value = mock_device
-
-        # Mock SampleFormat enum
-        mock_ma.SampleFormat.UNSIGNED8 = miniaudio.SampleFormat.UNSIGNED8
-        mock_ma.SampleFormat.SIGNED16 = miniaudio.SampleFormat.SIGNED16
-        mock_ma.SampleFormat.SIGNED24 = miniaudio.SampleFormat.SIGNED24
-        mock_ma.SampleFormat.SIGNED32 = miniaudio.SampleFormat.SIGNED32
-
-        yield {
-            'miniaudio_mock': mock_ma,
-            'device_mock': mock_device
-        }
+# mock_audio_stream, mock_media_file, playback_worker and mock_miniaudio
+# fixtures are shared with the coordinator tests via conftest.py.
 
 
 class TestPlaybackWorker:

--- a/tests/workers/gui/test_playback_worker.py
+++ b/tests/workers/gui/test_playback_worker.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 import miniaudio
 from unittest.mock import MagicMock, patch, PropertyMock
@@ -49,7 +51,13 @@ def mock_media_file(mock_audio_stream):
 @pytest.fixture
 def playback_worker(qapp):
     """Fixture to create a PlaybackWorker instance."""
-    return PlaybackWorker()
+    worker = PlaybackWorker()
+    yield worker
+    # Deterministic teardown: a started position timer must not outlive the
+    # test, or it fires into a destroyed QObject when a later test pumps the
+    # event loop (intermittent segfault/bus error mid-suite).
+    worker.timer.stop()
+    worker.state = STOPPED
 
 
 @pytest.fixture
@@ -351,3 +359,126 @@ class TestPlaybackWorker:
 
         # Verify get_audio_stream was called with None (all native = no adaptation needed)
         mock_media_file.get_audio_stream.assert_called_once_with(None)
+
+
+class TestPlaybackWorkerReleaseReacquire:
+    """Tests for the release/reacquire handshake used during file writes."""
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_release_for_write_saves_state_and_emits_paused(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.total_frames_read = 44100 * 3  # 3 seconds in
+
+        paused_spy = MagicMock()
+        playback_worker.playback_paused.connect(paused_spy)
+
+        event = threading.Event()
+        playback_worker.release_for_write("test.mp3", event)
+
+        assert event.is_set()
+        assert playback_worker.state == STOPPED
+        assert playback_worker._release_file_path == "test.mp3"
+        assert playback_worker._release_was_playing is True
+        assert playback_worker._release_saved_position == pytest.approx(3.0)
+        mock_miniaudio['device_mock'].close.assert_called_once()
+        mock_audio_stream.close.assert_called_once()
+        paused_spy.assert_called_once_with("test.mp3", 10.0)
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_release_for_write_non_matching_file_only_sets_event(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+
+        event = threading.Event()
+        playback_worker.release_for_write("other.mp3", event)
+
+        assert event.is_set()
+        assert playback_worker.state == PLAYING
+        assert playback_worker._release_file_path is None
+        mock_audio_stream.close.assert_not_called()
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_reacquire_after_write_resumes_at_position(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.total_frames_read = 44100 * 3
+        playback_worker.release_for_write("test.mp3", threading.Event())
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=mock_media_file) as media_file_cls:
+            playback_worker.reacquire_after_write()
+
+        media_file_cls.assert_called_once_with("test.mp3")
+        assert playback_worker.state == PLAYING
+        assert playback_worker.total_frames_read == 44100 * 3
+        mock_audio_stream.seek.assert_called_with(44100 * 3)
+        assert playback_worker._release_file_path is None
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_reacquire_after_write_repauses_when_was_paused(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.pause()
+        playback_worker.release_for_write("test.mp3", threading.Event())
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=mock_media_file):
+            playback_worker.reacquire_after_write()
+
+        assert playback_worker.state == PAUSED
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_reacquire_with_new_path_opens_new_file(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.release_for_write("test.mp3", threading.Event())
+
+        renamed_media_file = MagicMock(spec=MediaFile)
+        renamed_media_file.file_path = "renamed.mp3"
+        renamed_media_file.get_audio_stream.return_value = mock_audio_stream
+
+        started_spy = MagicMock()
+        playback_worker.playback_started.connect(started_spy)
+
+        with patch('workers.gui.playback_worker.MediaFile',
+                   return_value=renamed_media_file) as media_file_cls:
+            playback_worker.reacquire_after_write("renamed.mp3")
+
+        media_file_cls.assert_called_once_with("renamed.mp3")
+        assert playback_worker.current_file == "renamed.mp3"
+        started_spy.assert_called_once_with("renamed.mp3", 10.0)
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_stop_during_release_window_cancels_reacquire(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.release_for_write("test.mp3", threading.Event())
+
+        stopped_spy = MagicMock()
+        playback_worker.playback_stopped.connect(stopped_spy)
+
+        playback_worker.stop()
+
+        stopped_spy.assert_called_once()
+        assert playback_worker._release_file_path is None
+
+        # The write completing must not resurrect playback.
+        with patch('workers.gui.playback_worker.MediaFile') as media_file_cls:
+            playback_worker.reacquire_after_write()
+        media_file_cls.assert_not_called()
+        assert playback_worker.state == STOPPED
+
+    @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Crashes in github runner on qapp")
+    def test_stop_clears_current_file_so_release_skips(
+            self, playback_worker, mock_media_file, mock_audio_stream, mock_miniaudio):
+        playback_worker.start_playback(mock_media_file)
+        playback_worker.stop()
+
+        assert playback_worker.current_file is None
+
+        event = threading.Event()
+        playback_worker.release_for_write("test.mp3", event)
+
+        assert event.is_set()
+        assert playback_worker._release_file_path is None


### PR DESCRIPTION
## Summary

Implements a coordinated release/reacquire handshake between PlaybackWorker and PlaybackCoordinator to safely pause playback while files are being written to (metadata saves) or renamed. This ensures the audio stream is properly closed before disk operations, preventing permission errors and resource leaks.

## Key Changes

- **PlaybackWorker release/reacquire mechanism**: Added `release_for_write()` and `reacquire_after_write()` methods that pause playback, close the audio stream and device, save the playback position, and resume from that position after the write completes.

- **PlaybackCoordinator expansion**: Extended to coordinate both metadata saves (via `acquire_file`/`release_file`) and rename batches (via `begin_rename_batch`/`end_rename_batch`). The coordinator now properly handles the case where a rename batch holds the playback release, preventing concurrent save handshakes.

- **MiniaudioStream deterministic cleanup**: Added `_close_generator()` method to explicitly close the stream generator on `seek()` and `close()`, ensuring the underlying native file handle is released immediately rather than relying on garbage collection. This is critical for allowing metadata saves and renames to proceed without permission errors.

- **Main window rename integration**: Connected the rename batch lifecycle to the coordinator's begin/end methods, ensuring playback is paused during the rename operation and resumed at the file's new location.

- **Test infrastructure**: 
  - Extracted shared fixtures (`mock_audio_stream`, `mock_media_file`, `playback_worker`, `mock_miniaudio`) to `conftest.py` for reuse across playback tests
  - Added comprehensive test suite for release/reacquire handshake in `TestPlaybackWorkerReleaseReacquire`
  - Added new `test_playback_coordinator.py` with tests for save and rename batch coordination
  - Added `test_miniaudio_stream_release.py` to verify deterministic file handle cleanup

- **Bug fixes**:
  - Fixed `stop()` to properly cancel pending reacquires when user stops during a write
  - Fixed `release_for_write()` to handle edge cases (already stopped, no stream open)
  - Fixed edit manager thread cleanup to prevent race condition during worker deletion

## Notable Implementation Details

- The handshake uses `threading.Event` for synchronization between the main thread (coordinator) and playback thread (worker)
- During release, playback state is shown as PAUSED to keep the UI truthful while the file is temporarily unavailable
- Rename batches run under a modal dialog, so no additional locking is needed for the batch-level release
- The rename dispatcher repoints the MediaFile instance in place, so the coordinator doesn't need to track the new path—it just follows the instance's updated `file_path`
- MiniaudioStream's generator close is wrapped in exception handling to prevent cleanup errors from propagating

https://claude.ai/code/session_01QeTnfUqmZoCGUqhszATZPw