### PR TITLE
Bind playback to double-click and editing to middle-click

### DIFF
--- a/src/views/multi_select_preserving_tree_view.py
+++ b/src/views/multi_select_preserving_tree_view.py
@@ -1,17 +1,22 @@
-from PySide6.QtCore import Qt, QItemSelectionModel
+from PySide6.QtCore import Qt, QItemSelectionModel, QModelIndex
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QTreeView
 
 
 class MultiSelectPreservingTreeView(QTreeView):
     """
-    QTreeView that preserves an existing multi-row selection when the user
-    left-clicks on a row already in that selection.
+    QTreeView with custom mouse bindings for the file list:
+
+      * Left-click on a row already in a multi-row selection preserves that
+        selection instead of collapsing it to the clicked row.
+      * Middle-click opens the inline editor for the cell under the cursor.
+      * Double-click only emits doubleClicked (the owning window binds it to
+        playback); it no longer starts inline editing.
 
     Qt's default QAbstractItemView.mousePressEvent collapses the selection
     to the single clicked row on the first press of a double-click sequence.
     That defeats inline-editing delegates that apply the edit to every row
-    in the current selection. This subclass short-circuits that collapse
+    in the current selection. mousePressEvent short-circuits that collapse
     only when:
       * the button is LeftButton,
       * no keyboard modifiers are held,
@@ -24,20 +29,39 @@ class MultiSelectPreservingTreeView(QTreeView):
     context menus, Ctrl/Shift selection edits, empty-area deselect, and
     single-row click-to-select continue to work as before.
 
+    Middle-click mirrors the same selection semantics: inside a multi-row
+    selection it preserves the selection (so the delegate applies the edit
+    to all selected rows); otherwise it selects the clicked row first. The
+    editor is started with the unconditional edit() slot, so the view does
+    not need a DoubleClicked/SelectedClicked edit trigger.
+
     Caveat: because we consume the press on an already-selected row, an
     item drag initiated from such a row will not start. The view this class
     is used with today does not enable item drag, so this is a non-issue.
 
-    A second override on mouseDoubleClickEvent is required for a subtle
-    reason: QAbstractItemView.mouseDoubleClickEvent checks an internal
-    pressedIndex that only gets assigned inside the default mousePressEvent.
-    Because our mousePressEvent short-circuits super() in the multi-select
-    case, that pressedIndex stays stale and the default double-click
-    handler bails out without opening the editor. Our override starts the
-    editor explicitly for the multi-select case.
+    The mouseDoubleClickEvent override is required for a subtle reason:
+    QAbstractItemView.mouseDoubleClickEvent checks an internal pressedIndex
+    that only gets assigned inside the default mousePressEvent. Because our
+    mousePressEvent short-circuits super() in the multi-select case, that
+    pressedIndex stays stale and the default handler would not emit
+    doubleClicked, so the override emits it explicitly.
     """
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
+        if self._is_middle_click_on_index(event):
+            index = self.indexAt(event.position().toPoint())
+            if self._is_index_in_multi_selection(index):
+                # Preserve the multi-selection so the delegate applies the
+                # edit to every selected row.
+                self.selectionModel().setCurrentIndex(index, QItemSelectionModel.SelectionFlag.NoUpdate)
+            else:
+                self.selectionModel().setCurrentIndex(
+                    index,
+                    QItemSelectionModel.SelectionFlag.ClearAndSelect | QItemSelectionModel.SelectionFlag.Rows,
+                )
+            self.edit(index)
+            event.accept()
+            return
         if self._is_click_inside_multi_selection(event):
             index = self.indexAt(event.position().toPoint())
             self.selectionModel().setCurrentIndex(index, QItemSelectionModel.SelectionFlag.NoUpdate)
@@ -49,17 +73,25 @@ class MultiSelectPreservingTreeView(QTreeView):
         if self._is_click_inside_multi_selection(event):
             index = self.indexAt(event.position().toPoint())
             self.doubleClicked.emit(index)
-            self.edit(index)
             event.accept()
             return
         super().mouseDoubleClickEvent(event)
+
+    def _is_middle_click_on_index(self, event: QMouseEvent) -> bool:
+        if event.button() != Qt.MouseButton.MiddleButton:
+            return False
+        if event.modifiers() != Qt.KeyboardModifier.NoModifier:
+            return False
+        return self.indexAt(event.position().toPoint()).isValid()
 
     def _is_click_inside_multi_selection(self, event: QMouseEvent) -> bool:
         if event.button() != Qt.MouseButton.LeftButton:
             return False
         if event.modifiers() != Qt.KeyboardModifier.NoModifier:
             return False
-        index = self.indexAt(event.position().toPoint())
+        return self._is_index_in_multi_selection(self.indexAt(event.position().toPoint()))
+
+    def _is_index_in_multi_selection(self, index: QModelIndex) -> bool:
         if not index.isValid():
             return False
         selected_rows = self.selectionModel().selectedRows()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QAction, QActionGroup, QIcon
 from PySide6.QtCore import (
-    QDir, QThreadPool, Qt, QSortFilterProxyModel, QThread, QTimer, Slot, Signal
+    QDir, QModelIndex, QThreadPool, Qt, QSortFilterProxyModel, QThread, QTimer, Slot, Signal
 )
 
 import windows
@@ -175,6 +175,10 @@ class MainWindow(QMainWindow):
         self.files_view.setItemDelegate(self.editable_delegate)
         self.files_view.setSortingEnabled(True)
         self.files_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        # Double-click starts playback and middle-click opens the inline
+        # editor (handled by MultiSelectPreservingTreeView), so drop the
+        # default DoubleClicked edit trigger. F2 still edits.
+        self.files_view.setEditTriggers(QAbstractItemView.EditTrigger.EditKeyPressed)
 
         # Give the delegate access to selection context for multi-file inline editing
         self.editable_delegate.set_selection_model(self.files_view.selectionModel())
@@ -1415,10 +1419,10 @@ class MainWindow(QMainWindow):
             self.properties_window = windows.PropertiesWindow(media_files, self.edit_manager, self)
             self.properties_window.show()
 
-    def on_files_view_double_clicked(self, index):
-        # Inline editing is handled by the delegate for both single and multi-select.
-        # The delegate applies changes to all selected rows via setDataForRows().
-        pass
+    def on_files_view_double_clicked(self, index: QModelIndex) -> None:
+        # Play the file under the cursor, regardless of how many rows are
+        # selected. Inline editing is bound to middle-click in the view.
+        self._start_playback_for_proxy_index(index)
 
     def on_column_resized(self, logical_index, old_size, new_size):
         # This is now handled by _save_column_settings, which reads the visual layout
@@ -1702,13 +1706,22 @@ class MainWindow(QMainWindow):
         """
         selected_indexes = self.files_view.selectionModel().selectedRows()
         if len(selected_indexes) == 1:
-            source_index = self.proxy_model.mapToSource(selected_indexes[0])
-            row_data = self.file_model.get_data_for_row(row=source_index.row())
-            file_path = row_data.get(KEY_FILE_PATH)
-            if file_path and row_data.get(KEY_IS_MEDIA):
-                media_file = MediaFile(file_path)
-                self.playback_panel.show()
-                self.start_playback_signal.emit(media_file)
+            self._start_playback_for_proxy_index(selected_indexes[0])
+
+    def _start_playback_for_proxy_index(self, proxy_index: QModelIndex) -> None:
+        """
+        Starts playback of the media file at the given files_view (proxy)
+        index. Non-media rows and invalid indexes are ignored.
+        """
+        if not proxy_index.isValid():
+            return
+        source_index = self.proxy_model.mapToSource(proxy_index)
+        row_data = self.file_model.get_data_for_row(row=source_index.row())
+        file_path = row_data.get(KEY_FILE_PATH)
+        if file_path and row_data.get(KEY_IS_MEDIA):
+            media_file = MediaFile(file_path)
+            self.playback_panel.show()
+            self.start_playback_signal.emit(media_file)
 
     def on_open_in_file_browser(self):
         """

--- a/tests/views/test_multi_select_preserving_tree_view.py
+++ b/tests/views/test_multi_select_preserving_tree_view.py
@@ -47,6 +47,12 @@ def _click_center_of(view, index, modifier=Qt.KeyboardModifier.NoModifier):
     QTest.mouseClick(view.viewport(), Qt.MouseButton.LeftButton, modifier, rect.center())
 
 
+def _middle_click_center_of(view, index):
+    """Synthesize a middle-click at the center of the given index's visual rect."""
+    rect = view.visualRect(index)
+    QTest.mouseClick(view.viewport(), Qt.MouseButton.MiddleButton, Qt.KeyboardModifier.NoModifier, rect.center())
+
+
 def _selected_rows_set(view):
     return {idx.row() for idx in view.selectionModel().selectedRows()}
 
@@ -123,13 +129,13 @@ class _RecordingDelegate(QStyledItemDelegate):
 
 
 @pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)
-def test_double_click_on_selected_row_opens_editor_and_preserves_selection(qapp):
-    """Double-click on a row inside a multi-row selection must both open
-    the editor and leave the full selection intact."""
+def test_double_click_on_selected_row_emits_signal_without_editing(qapp):
+    """Double-click on a row inside a multi-row selection must emit
+    doubleClicked for the row under the cursor, preserve the selection,
+    and NOT open an inline editor (editing is bound to middle-click)."""
     view, model = _make_view_with_model(qapp)
     delegate = _RecordingDelegate()
     view.setItemDelegate(delegate)
-    view.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked)
 
     _select_rows(view, [1, 2, 3])
 
@@ -144,10 +150,75 @@ def test_double_click_on_selected_row_opens_editor_and_preserves_selection(qapp)
     )
 
     assert _selected_rows_set(view) == {1, 2, 3}
-    assert (2, 0) in delegate.edited_indexes, (
-        f"Expected an editor to be created for (row=2, col=0); got {delegate.edited_indexes}"
+    assert delegate.edited_indexes == [], (
+        f"Double-click must not open an editor; got {delegate.edited_indexes}"
     )
     assert double_clicked_spy.count() == 1
+    assert double_clicked_spy.at(0)[0].row() == 2
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)
+def test_middle_click_on_unselected_row_selects_it_and_opens_editor(qapp):
+    """Middle-click on an unselected row must select it and open the
+    inline editor for the cell under the cursor."""
+    view, model = _make_view_with_model(qapp)
+    delegate = _RecordingDelegate()
+    view.setItemDelegate(delegate)
+
+    _middle_click_center_of(view, model.index(3, 1))
+
+    assert _selected_rows_set(view) == {3}
+    assert view.selectionModel().currentIndex().row() == 3
+    assert (3, 1) in delegate.edited_indexes, (
+        f"Expected an editor to be created for (row=3, col=1); got {delegate.edited_indexes}"
+    )
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)
+def test_middle_click_inside_multi_selection_preserves_it_and_opens_editor(qapp):
+    """Middle-click on a row inside a multi-row selection must preserve
+    the selection (so the delegate can edit all rows) and open the editor."""
+    view, model = _make_view_with_model(qapp)
+    delegate = _RecordingDelegate()
+    view.setItemDelegate(delegate)
+
+    _select_rows(view, [1, 2, 3])
+
+    _middle_click_center_of(view, model.index(2, 0))
+
+    assert _selected_rows_set(view) == {1, 2, 3}
+    assert view.selectionModel().currentIndex().row() == 2
+    assert (2, 0) in delegate.edited_indexes
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)
+def test_middle_click_outside_multi_selection_collapses_to_it_and_opens_editor(qapp):
+    """Middle-click on a row outside the current selection must collapse
+    the selection to the clicked row and open the editor."""
+    view, model = _make_view_with_model(qapp)
+    delegate = _RecordingDelegate()
+    view.setItemDelegate(delegate)
+
+    _select_rows(view, [1, 2, 3])
+
+    _middle_click_center_of(view, model.index(4, 0))
+
+    assert _selected_rows_set(view) == {4}
+    assert (4, 0) in delegate.edited_indexes
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)
+def test_middle_click_on_empty_area_opens_no_editor(qapp):
+    """Middle-click below the last row must not open an editor."""
+    view, model = _make_view_with_model(qapp)
+    delegate = _RecordingDelegate()
+    view.setItemDelegate(delegate)
+
+    last_rect = view.visualRect(model.index(NUM_ROWS - 1, 0))
+    empty_point = QPoint(last_rect.center().x(), last_rect.bottom() + 40)
+    QTest.mouseClick(view.viewport(), Qt.MouseButton.MiddleButton, Qt.KeyboardModifier.NoModifier, empty_point)
+
+    assert delegate.edited_indexes == []
 
 
 @pytest.mark.skipif(IN_GITHUB_RUNNER, reason=SKIP_REASON)

--- a/tests/windows/test_main_window_playback.py
+++ b/tests/windows/test_main_window_playback.py
@@ -1,0 +1,93 @@
+import os
+
+import pytest
+from unittest.mock import patch
+from PySide6.QtCore import QModelIndex, QSettings
+from PySide6.QtTest import QSignalSpy
+
+from util.const import IN_GITHUB_RUNNER, KEY_FILE_PATH, KEY_IS_MEDIA
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "metadata")
+MEDIA_FIXTURE = os.path.abspath(os.path.join(FIXTURES_DIR, "sample_dtmf_nometa.mp3"))
+NON_MEDIA_FIXTURE = os.path.abspath(os.path.join(FIXTURES_DIR, "sample_dtmf_nometa.mp3.json"))
+
+
+@pytest.fixture
+def test_settings():
+    """Clean QSettings instance so tests do not touch real user settings."""
+    settings = QSettings("LyjiaTest", "Audio Metadata Tool Test")
+    settings.clear()
+    yield settings
+    settings.clear()
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
+class TestMainWindowPlaybackBinds:
+    """Playback initiation from the files view (double-click) and the menu action."""
+
+    @pytest.fixture
+    def main_window(self, qapp, test_settings):
+        with patch('windows.main_window.settings', test_settings):
+            from windows.main_window import MainWindow
+            window = MainWindow()
+            # Detach the worker so no audio device is touched; the emitted
+            # signal is observed with a QSignalSpy instead.
+            window.start_playback_signal.disconnect(window.playback_worker.start_playback)
+            window.file_model.set_entire_data([
+                {KEY_FILE_PATH: MEDIA_FIXTURE, KEY_IS_MEDIA: True},
+                {KEY_FILE_PATH: NON_MEDIA_FIXTURE, KEY_IS_MEDIA: False},
+            ])
+            yield window
+            window.close()
+
+    def _proxy_index_for_row(self, main_window, row: int) -> QModelIndex:
+        return main_window.proxy_model.mapFromSource(main_window.file_model.index(row, 0))
+
+    def test_double_click_on_media_row_starts_playback(self, main_window):
+        spy = QSignalSpy(main_window.start_playback_signal)
+        main_window.playback_panel.hide()
+
+        main_window.on_files_view_double_clicked(self._proxy_index_for_row(main_window, 0))
+
+        assert spy.count() == 1
+        media_file = spy.at(0)[0]
+        assert media_file.file_path == MEDIA_FIXTURE
+        assert not main_window.playback_panel.isHidden()
+
+    def test_double_click_on_non_media_row_does_nothing(self, main_window):
+        spy = QSignalSpy(main_window.start_playback_signal)
+
+        main_window.on_files_view_double_clicked(self._proxy_index_for_row(main_window, 1))
+
+        assert spy.count() == 0
+
+    def test_double_click_with_invalid_index_does_nothing(self, main_window):
+        spy = QSignalSpy(main_window.start_playback_signal)
+
+        main_window.on_files_view_double_clicked(QModelIndex())
+
+        assert spy.count() == 0
+
+    def test_play_action_with_single_selection_starts_playback(self, main_window):
+        spy = QSignalSpy(main_window.start_playback_signal)
+        main_window.files_view.selectionModel().select(
+            self._proxy_index_for_row(main_window, 0),
+            main_window.files_view.selectionModel().SelectionFlag.ClearAndSelect
+            | main_window.files_view.selectionModel().SelectionFlag.Rows,
+        )
+
+        main_window.on_play_file_requested()
+
+        assert spy.count() == 1
+        assert spy.at(0)[0].file_path == MEDIA_FIXTURE
+
+    def test_play_action_with_multi_selection_does_nothing(self, main_window):
+        spy = QSignalSpy(main_window.start_playback_signal)
+        sel_model = main_window.files_view.selectionModel()
+        flags = sel_model.SelectionFlag.Select | sel_model.SelectionFlag.Rows
+        sel_model.select(self._proxy_index_for_row(main_window, 0), flags)
+        sel_model.select(self._proxy_index_for_row(main_window, 1), flags)
+
+        main_window.on_play_file_requested()
+
+        assert spy.count() == 0


### PR DESCRIPTION
## Summary
Rebind user interactions in the files view to improve the editing workflow:
- Double-click now starts playback instead of opening the inline editor
- Middle-click opens the inline editor (replacing the previous double-click behavior)
- Left-click continues to handle selection as before

## Key Changes

**Main Window (`src/windows/main_window.py`)**
- Removed the `DoubleClicked` edit trigger from the files view; now only `EditKeyPressed` (F2) and middle-click trigger editing
- Implemented `_start_playback_for_proxy_index()` helper method to handle playback initiation
- Updated `on_files_view_double_clicked()` to start playback instead of being a no-op
- Updated `on_play_file_requested()` to use the new helper method

**Multi-Select Preserving Tree View (`src/views/multi_select_preserving_tree_view.py`)**
- Added middle-click handling in `mousePressEvent()` to open the inline editor while respecting multi-row selections
- Updated `mouseDoubleClickEvent()` to emit `doubleClicked` without starting the editor
- Added helper methods `_is_middle_click_on_index()` and `_is_index_in_multi_selection()` to support the new behavior
- Updated class docstring to document the new mouse bindings

**Tests**
- Added comprehensive test suite (`tests/windows/test_main_window_playback.py`) covering playback initiation via double-click and menu action, including edge cases (non-media files, invalid indexes, multi-selection)
- Updated existing tree view tests (`tests/views/test_multi_select_preserving_tree_view.py`) to reflect the new behavior:
  - Renamed and updated the double-click test to verify signal emission without editing
  - Added four new tests for middle-click behavior (unselected row, inside multi-selection, outside multi-selection, empty area)

## Implementation Details
- The multi-select preservation logic now applies to both left-click and middle-click, ensuring that inline editing delegates can apply changes to all selected rows
- Invalid indexes and non-media files are safely ignored during playback initiation
- The playback panel is automatically shown when playback starts

https://claude.ai/code/session_01Wa5atHZVNon6UFeSXixp64