### PR TITLE
Add manual refresh (F5) and improve directory pane handling

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -8,7 +8,8 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QAction, QActionGroup, QIcon
 from PySide6.QtCore import (
-    QDir, QThreadPool, Qt, QSortFilterProxyModel, QThread, QTimer, Slot, Signal
+    QDir, QThreadPool, Qt, QSignalBlocker, QSortFilterProxyModel, QThread,
+    QTimer, Slot, Signal
 )
 
 import windows
@@ -61,6 +62,9 @@ class MainWindow(QMainWindow):
         self._current_worker_id = 0
         self._saved_sort_column = None
         self._saved_sort_order = None
+        # File paths to re-select once the current load finishes. Only a
+        # manual refresh sets this; normal navigation always clears it.
+        self._pending_selection_paths = None
 
         # Playback components
         self.playback_panel = PlaybackPanel()
@@ -348,13 +352,31 @@ class MainWindow(QMainWindow):
         settings.setValue("last_path", path)
 
     def on_directory_changed(self, current, previous):
+        path = self.dir_model.filePath(current)
+        self._load_directory(path)
+
+    def _load_directory(self, path: str, restore_selection: list[str] | None = None) -> None:
+        """
+        Reload the file pane with the contents of the given directory.
+
+        Args:
+            path: Directory to scan.
+            restore_selection: File paths to re-select once the load
+                finishes. Normal navigation must leave this as None so a
+                superseded refresh never restores a stale selection.
+        """
+        self._pending_selection_paths = restore_selection
+
         # Cancel any existing load operation
         if self._current_load_worker is not None:
             log.debug("Cancelling previous load worker due to directory change")
             self._current_load_worker.cancel()
 
-        path = self.dir_model.filePath(current)
-        self.set_path(path)
+        # set_path re-points the directory tree's current index. Block the
+        # tree's selection signals so that a changed index cannot re-enter
+        # on_directory_changed and start a second, competing load.
+        with QSignalBlocker(self.directory_tree.selectionModel()):
+            self.set_path(path)
 
         # Clear the model for the new directory
         self.file_model.set_entire_data([])
@@ -498,6 +520,13 @@ class MainWindow(QMainWindow):
 
         # Re-enable sorting
         self.files_view.setSortingEnabled(True)
+
+        # Restore the selection captured by a manual refresh. The worker-id
+        # guard above ensures a refresh superseded by navigation never gets
+        # here with a stale pending list.
+        if self._pending_selection_paths:
+            self._on_select_analyzer_files(self._pending_selection_paths)
+        self._pending_selection_paths = None
 
         self.progress_bar.hide()
         self.cancel_button.hide()
@@ -1093,7 +1122,7 @@ class MainWindow(QMainWindow):
         if paths_changed and self._current_path:
             # Full rescan: file paths have changed (e.g. after rename).
             log.info("Batch changed file paths; triggering full directory rescan")
-            self.set_path(self._current_path)
+            self._load_directory(self._current_path)
             return
 
         file_ids = [mf.file_id for mf in media_files]
@@ -1117,19 +1146,7 @@ class MainWindow(QMainWindow):
         then drives a RenameDispatcher through the shared progress/summary
         dialogs and refreshes the file list.
         """
-        selected_indexes = self.files_view.selectionModel().selectedRows()
-        if not selected_indexes:
-            log.debug("No files selected for rename")
-            return
-
-        media_files = []
-        for index in selected_indexes:
-            source_index = self.proxy_model.mapToSource(index)
-            row_data = self.file_model.get_data_for_row(row=source_index.row())
-            file_path = row_data.get(KEY_FILE_PATH)
-            if file_path and row_data.get(KEY_IS_MEDIA):
-                media_files.append(MediaFile(file_path, enable_write=True))
-
+        media_files = self._get_selected_media_files()
         if not media_files:
             log.debug("No valid media files selected for rename")
             return
@@ -1192,7 +1209,7 @@ class MainWindow(QMainWindow):
             # on-completion refresh already updated the list, but a rescan
             # ensures any new files, timestamps, etc. are picked up cleanly.
             if self._current_path:
-                self.set_path(self._current_path)
+                self._load_directory(self._current_path)
 
     @Slot(list)
     def _on_select_analyzer_files(self, file_paths: list):
@@ -1399,21 +1416,33 @@ class MainWindow(QMainWindow):
         menu.clear()
         self._populate_favorites_menu(menu)
 
-    def open_properties_window(self):
-        selected_indexes = self.files_view.selectionModel().selectedRows()
-        log.debug(f"selectedIndexes from selectionModel: {selected_indexes} (type: {type(selected_indexes)})")
-
-        if not selected_indexes:
-            log.debug("No selected indexes, returning.")
-            return
-
-        media_files = []
-        for index in selected_indexes:
+    def _get_selected_row_data(self) -> list[dict]:
+        """Row data dicts for the currently selected file rows."""
+        rows = []
+        for index in self.files_view.selectionModel().selectedRows():
             source_index = self.proxy_model.mapToSource(index)
-            row_data = self.file_model.get_data_for_row( row=source_index.row() )
+            rows.append(self.file_model.get_data_for_row(row=source_index.row()))
+        return rows
+
+    def _get_selected_file_paths(self) -> list[str]:
+        """File paths of all currently selected rows."""
+        return [
+            row_data.get(KEY_FILE_PATH)
+            for row_data in self._get_selected_row_data()
+            if row_data.get(KEY_FILE_PATH)
+        ]
+
+    def _get_selected_media_files(self) -> list[MediaFile]:
+        """Writable MediaFile instances for the selected media-file rows."""
+        media_files = []
+        for row_data in self._get_selected_row_data():
             file_path = row_data.get(KEY_FILE_PATH)
             if file_path and row_data.get(KEY_IS_MEDIA):
                 media_files.append(MediaFile(file_path, enable_write=True))
+        return media_files
+
+    def open_properties_window(self):
+        media_files = self._get_selected_media_files()
 
         if media_files:
             self.properties_window = windows.PropertiesWindow(media_files, self.edit_manager, self)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QLineEdit, QSizePolicy, QFileDialog, QAbstractItemView, QVBoxLayout, QWidget,
     QDialog, QToolButton
 )
-from PySide6.QtGui import QAction, QActionGroup, QIcon
+from PySide6.QtGui import QAction, QActionGroup, QIcon, QKeySequence
 from PySide6.QtCore import (
     QDir, QThreadPool, Qt, QSignalBlocker, QSortFilterProxyModel, QThread,
     QTimer, Slot, Signal
@@ -87,8 +87,10 @@ class MainWindow(QMainWindow):
         self.toolbar.addAction(action_open)
 
         refresh_icon = self.style().standardIcon(QStyle.StandardPixmap.SP_BrowserReload)
-        action_refresh = QAction(refresh_icon, "Refresh", self)
-        self.toolbar.addAction(action_refresh)
+        self.action_refresh = QAction(refresh_icon, "Refresh", self)
+        self.action_refresh.setShortcut(QKeySequence(Qt.Key.Key_F5))
+        self.action_refresh.triggered.connect(self.on_refresh_requested)
+        self.toolbar.addAction(self.action_refresh)
 
         # Add Favorites toolbar button
         self.favorites_button = QToolButton()
@@ -136,13 +138,7 @@ class MainWindow(QMainWindow):
 
         # Left Pane (Directory Tree)
         self.directory_tree = QTreeView()
-        self.dir_model = QFileSystemModel()
-        self.dir_model.setFilter(QDir.NoDotAndDotDot | QDir.AllDirs)
-        self.dir_model.setRootPath("")
-        self.directory_tree.setModel(self.dir_model)
-        self.directory_tree.setRootIndex(self.dir_model.index(""))
-        for i in range(1, self.dir_model.columnCount()):
-            self.directory_tree.hideColumn(i)
+        self._install_dir_model()
         splitter.addWidget(self.directory_tree)
 
         # Connect to EditManager signals
@@ -206,8 +202,7 @@ class MainWindow(QMainWindow):
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
 
-        # Connect the panes
-        self.directory_tree.selectionModel().currentChanged.connect(self.on_directory_changed)
+        # Connect the panes (the directory tree is wired in _install_dir_model)
         self.files_view.selectionModel().selectionChanged.connect(self.update_file_actions)
 
         # Connect header signals
@@ -350,6 +345,57 @@ class MainWindow(QMainWindow):
         index = self.dir_model.index(path)
         self.directory_tree.setCurrentIndex(index)
         settings.setValue("last_path", path)
+
+    def _install_dir_model(self) -> None:
+        """
+        (Re)create the directory tree's QFileSystemModel and wire it up.
+
+        Shared by __init__ and _refresh_directory_pane: QFileSystemModel has
+        no public API to re-read the filesystem, so a manual refresh installs
+        a fresh model through this same path.
+        """
+        self.dir_model = QFileSystemModel()
+        self.dir_model.setFilter(QDir.NoDotAndDotDot | QDir.AllDirs)
+        self.dir_model.setRootPath("")
+        self.directory_tree.setModel(self.dir_model)
+        self.directory_tree.setRootIndex(self.dir_model.index(""))
+        for i in range(1, self.dir_model.columnCount()):
+            self.directory_tree.hideColumn(i)
+        # setModel() replaces the view's selection model, so the navigation
+        # signal must be (re)connected on every install.
+        self.directory_tree.selectionModel().currentChanged.connect(self.on_directory_changed)
+
+    def _refresh_directory_pane(self) -> None:
+        """
+        Force the directory tree to re-read the filesystem by replacing its
+        model, then restore the current directory. Revealing the restored
+        index re-expands the path to it, matching the state right after a
+        normal navigation.
+        """
+        old_model = self.dir_model
+        self._install_dir_model()
+        old_model.deleteLater()
+        # Block the fresh selection model's signals: setCurrentIndex would
+        # otherwise emit currentChanged and start a competing load without
+        # the caller's selection restore.
+        with QSignalBlocker(self.directory_tree.selectionModel()):
+            self.directory_tree.setCurrentIndex(self.dir_model.index(self._current_path))
+
+    def on_refresh_requested(self) -> None:
+        """
+        Manually reload both panes (F5 / View > Refresh / toolbar button) as
+        if the user had just navigated to the current directory, restoring
+        the file selection once the reload completes.
+        """
+        if not self._current_path or not os.path.isdir(self._current_path):
+            log.warning(f"Cannot refresh: {self._current_path!r} is not a directory")
+            self.status_label.setText("Cannot refresh: current directory is unavailable.")
+            return
+
+        log.info(f"Manual refresh of {self._current_path}")
+        selected = self._get_selected_file_paths()
+        self._refresh_directory_pane()
+        self._load_directory(self._current_path, restore_selection=selected)
 
     def on_directory_changed(self, current, previous):
         path = self.dir_model.filePath(current)
@@ -741,6 +787,8 @@ class MainWindow(QMainWindow):
         self.view_menu.addAction(action_reset_columns)
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.action_show_playback_panel)
+        self.view_menu.addSeparator()
+        self.view_menu.addAction(self.action_refresh)
 
         # Favorites Menu - shared between menu bar and toolbar
         self.favorites_menu = self._create_favorites_menu()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -591,7 +591,13 @@ class MainWindow(QMainWindow):
         if col_settings:
             col_settings.is_visible = checked
 
-    def setup_columns_in_view_menu(self, view_menu):
+    def _rebuild_column_menu(self) -> None:
+        """
+        Rebuild the Columns submenu to match the current file model columns.
+
+        Only the submenu is rebuilt; the View menu itself is constructed once
+        in _create_menus() so its other actions are never wiped.
+        """
         self.column_menu.clear()
         for i in range(self.file_model.columnCount()):
             action = QAction(self.file_model.headerData(i, Qt.Horizontal), self)
@@ -600,12 +606,6 @@ class MainWindow(QMainWindow):
             action.setData(i)
             action.toggled.connect(lambda checked, index=i: self.toggle_column(index, checked))
             self.column_menu.addAction(action)
-        view_menu.clear()
-        view_menu.addMenu(self.column_menu)
-        action_reset_columns = QAction("Reset Columns", self)
-
-        action_reset_columns.triggered.connect(self._reset_column_settings)
-        self.view_menu.addAction(action_reset_columns)
 
     def open_folder(self):
         folder_path = QFileDialog.getExistingDirectory(self, "Select Folder", self._current_path)
@@ -705,7 +705,11 @@ class MainWindow(QMainWindow):
 
         # View Menu
         self.view_menu = self.menuBar().addMenu("&View")
-        self.setup_columns_in_view_menu(self.view_menu)
+        self._rebuild_column_menu()
+        self.view_menu.addMenu(self.column_menu)
+        action_reset_columns = QAction("Reset Columns", self)
+        action_reset_columns.triggered.connect(self._reset_column_settings)
+        self.view_menu.addAction(action_reset_columns)
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.action_show_playback_panel)
 
@@ -1540,7 +1544,7 @@ class MainWindow(QMainWindow):
         self.file_model = MetadataTableModel(self.file_list_settings.columns, self.edit_manager)
         self.proxy_model.setSourceModel(self.file_model)
         self._apply_column_settings()
-        self.setup_columns_in_view_menu(self.view_menu)
+        self._rebuild_column_menu()
 
     def _get_column_settings_by_logical_index(self, logical_index):
         if logical_index < 0 or logical_index >= len(self._logical_column_ids):

--- a/tests/windows/test_main_window_refresh.py
+++ b/tests/windows/test_main_window_refresh.py
@@ -11,7 +11,7 @@ lazily inside the tests (same pattern as the autosave test suite).
 import pytest
 from unittest.mock import patch
 
-from util.const import IN_GITHUB_RUNNER
+from util.const import IN_GITHUB_RUNNER, KEY_FILE_PATH
 
 
 @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
@@ -29,6 +29,50 @@ class TestMainWindowRefresh:
             window.edit_manager.reset_changes()
             window.edit_manager.set_autosave(True)
             window.close()
+
+    @staticmethod
+    def _complete_load(main_window, directory, file_paths, restore_selection=None):
+        """
+        Drive _load_directory through a synchronous fake of the async load:
+        the thread pool is stubbed out, rows are injected by hand, and the
+        worker-finished handler is invoked directly.
+        """
+        with patch.object(main_window.thread_pool, "start"):
+            main_window._load_directory(str(directory), restore_selection=restore_selection)
+            main_window.file_model.add_rows([{KEY_FILE_PATH: p} for p in file_paths])
+            main_window.on_worker_finished(main_window._current_worker_id)
+
+    def test_refresh_restores_selection_after_load(self, main_window, tmp_path):
+        paths = [str(tmp_path / f"track{i}.mp3") for i in range(3)]
+
+        self._complete_load(main_window, tmp_path, paths,
+                            restore_selection=[paths[0], paths[2]])
+
+        assert sorted(main_window._get_selected_file_paths()) == sorted([paths[0], paths[2]])
+        assert main_window._pending_selection_paths is None
+
+    def test_normal_navigation_does_not_restore_selection(self, main_window, tmp_path):
+        paths = [str(tmp_path / f"track{i}.mp3") for i in range(2)]
+        # A stale pending list from an earlier refresh must be discarded by
+        # plain navigation.
+        main_window._pending_selection_paths = paths
+
+        self._complete_load(main_window, tmp_path, paths)
+
+        assert main_window._get_selected_file_paths() == []
+        assert main_window._pending_selection_paths is None
+
+    def test_stale_worker_does_not_restore_selection(self, main_window, tmp_path):
+        paths = [str(tmp_path / "track0.mp3")]
+
+        with patch.object(main_window.thread_pool, "start"):
+            main_window._load_directory(str(tmp_path), restore_selection=paths)
+            main_window.file_model.add_rows([{KEY_FILE_PATH: p} for p in paths])
+            # A finished signal from a superseded worker must be ignored.
+            main_window.on_worker_finished(main_window._current_worker_id - 1)
+
+        assert main_window._get_selected_file_paths() == []
+        assert main_window._pending_selection_paths == paths
 
     def test_view_menu_survives_reset_columns(self, main_window):
         actions_before = main_window.view_menu.actions()

--- a/tests/windows/test_main_window_refresh.py
+++ b/tests/windows/test_main_window_refresh.py
@@ -9,6 +9,7 @@ lazily inside the tests (same pattern as the autosave test suite).
 """
 
 import shutil
+from pathlib import Path
 
 import pytest
 from unittest.mock import patch
@@ -133,13 +134,15 @@ class TestMainWindowRefresh:
             assert main_window.dir_model is not old_model
             assert main_window.directory_tree.model() is main_window.dir_model
             current = main_window.directory_tree.currentIndex()
-            assert main_window.dir_model.filePath(current) == str(dir_a)
+            # QFileSystemModel.filePath returns forward slashes on Windows;
+            # compare as Paths to stay separator-agnostic.
+            assert Path(main_window.dir_model.filePath(current)) == dir_a
             assert main_window._current_worker_id == worker_id_before
 
             # Real navigation must still reach on_directory_changed through
             # the recreated selection model.
             main_window.directory_tree.setCurrentIndex(main_window.dir_model.index(str(dir_b)))
-            assert main_window._current_path == str(dir_b)
+            assert Path(main_window._current_path) == dir_b
             assert main_window._current_worker_id == worker_id_before + 1
 
     def test_staged_edits_survive_refresh(self, main_window, tmp_path):

--- a/tests/windows/test_main_window_refresh.py
+++ b/tests/windows/test_main_window_refresh.py
@@ -1,0 +1,43 @@
+"""
+Tests for the main window's manual refresh feature (F5 / View > Refresh)
+and the View menu construction it depends on.
+
+``windows.main_window.settings`` is patched explicitly to the isolated
+store: the conftest's autouse fixture only rebinds aliases in modules
+already imported when it runs, and this module imports main_window
+lazily inside the tests (same pattern as the autosave test suite).
+"""
+
+import pytest
+from unittest.mock import patch
+
+from util.const import IN_GITHUB_RUNNER
+
+
+@pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
+class TestMainWindowRefresh:
+
+    @pytest.fixture
+    def main_window(self, qapp, isolated_qsettings):
+        import windows.main_window as main_window_mod
+
+        with patch.object(main_window_mod, 'settings', isolated_qsettings):
+            window = main_window_mod.MainWindow()
+            yield window
+            # Leave the singleton EditManager clean for other tests, and make
+            # sure closeEvent doesn't open the blocking unsaved-changes dialog.
+            window.edit_manager.reset_changes()
+            window.edit_manager.set_autosave(True)
+            window.close()
+
+    def test_view_menu_survives_reset_columns(self, main_window):
+        actions_before = main_window.view_menu.actions()
+        assert main_window.action_show_playback_panel in actions_before
+
+        main_window._reset_column_settings()
+
+        actions_after = main_window.view_menu.actions()
+        assert main_window.action_show_playback_panel in actions_after
+        # The column submenu and Reset Columns entry must still be present.
+        assert main_window.column_menu.menuAction() in actions_after
+        assert any(a.text() == "Reset Columns" for a in actions_after)

--- a/tests/windows/test_main_window_refresh.py
+++ b/tests/windows/test_main_window_refresh.py
@@ -8,10 +8,15 @@ already imported when it runs, and this module imports main_window
 lazily inside the tests (same pattern as the autosave test suite).
 """
 
+import shutil
+
 import pytest
 from unittest.mock import patch
 
-from util.const import IN_GITHUB_RUNNER, KEY_FILE_PATH
+from util.const import IN_GITHUB_RUNNER, KEY_FILE_PATH, KEY_TITLE, PROJECT_ROOT
+
+
+FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "metadata" / "sample_dtmf_unicode.mp3"
 
 
 @pytest.mark.skipif(IN_GITHUB_RUNNER, reason="Qt widgets crash in GitHub Actions runner")
@@ -77,11 +82,82 @@ class TestMainWindowRefresh:
     def test_view_menu_survives_reset_columns(self, main_window):
         actions_before = main_window.view_menu.actions()
         assert main_window.action_show_playback_panel in actions_before
+        assert main_window.action_refresh in actions_before
 
         main_window._reset_column_settings()
 
         actions_after = main_window.view_menu.actions()
         assert main_window.action_show_playback_panel in actions_after
+        assert main_window.action_refresh in actions_after
         # The column submenu and Reset Columns entry must still be present.
         assert main_window.column_menu.menuAction() in actions_after
         assert any(a.text() == "Reset Columns" for a in actions_after)
+
+    def test_refresh_action_wiring(self, main_window):
+        from PySide6.QtGui import QKeySequence
+
+        # One action, two surfaces: toolbar and View menu.
+        assert main_window.action_refresh in main_window.toolbar.actions()
+        assert main_window.action_refresh in main_window.view_menu.actions()
+        assert QKeySequence("F5") in main_window.action_refresh.shortcuts()
+
+        with patch.object(main_window, 'on_refresh_requested') as handler:
+            main_window.action_refresh.trigger()
+        handler.assert_called_once()
+
+    def test_refresh_ignored_when_directory_unavailable(self, main_window, tmp_path):
+        gone = tmp_path / "gone"
+        gone.mkdir()
+        with patch.object(main_window.thread_pool, "start"):
+            main_window._load_directory(str(gone))
+            gone.rmdir()
+            worker_id_before = main_window._current_worker_id
+            main_window.on_refresh_requested()
+        assert main_window._current_worker_id == worker_id_before
+
+    def test_directory_pane_rebuild_restores_current_and_reconnects(self, main_window, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        dir_b = tmp_path / "b"
+        dir_b.mkdir()
+
+        with patch.object(main_window.thread_pool, "start"):
+            main_window._load_directory(str(dir_a))
+            old_model = main_window.dir_model
+            worker_id_before = main_window._current_worker_id
+
+            main_window._refresh_directory_pane()
+
+            # Fresh model installed on the view, current directory restored,
+            # and the signal-blocked restore did not start a competing load.
+            assert main_window.dir_model is not old_model
+            assert main_window.directory_tree.model() is main_window.dir_model
+            current = main_window.directory_tree.currentIndex()
+            assert main_window.dir_model.filePath(current) == str(dir_a)
+            assert main_window._current_worker_id == worker_id_before
+
+            # Real navigation must still reach on_directory_changed through
+            # the recreated selection model.
+            main_window.directory_tree.setCurrentIndex(main_window.dir_model.index(str(dir_b)))
+            assert main_window._current_path == str(dir_b)
+            assert main_window._current_worker_id == worker_id_before + 1
+
+    def test_staged_edits_survive_refresh(self, main_window, tmp_path):
+        from models.media_file import MediaFile
+
+        target = tmp_path / "sample.mp3"
+        shutil.copy(FIXTURE, target)
+
+        edit_manager = main_window.edit_manager
+        edit_manager.set_autosave(False)
+        media_file = MediaFile(str(target))  # read-only; never saved here
+        edit_manager.register_media_files([media_file])
+        edit_manager.stage_change([media_file], KEY_TITLE, "Queued Title")
+        assert edit_manager.has_staged_changes()
+
+        with patch.object(main_window.thread_pool, "start"):
+            main_window._load_directory(str(tmp_path))
+            main_window.on_refresh_requested()
+
+        assert edit_manager.has_staged_changes()
+        assert edit_manager.get_staged_value(media_file.file_id, KEY_TITLE) == "Queued Title"

--- a/tests/workers/test_rename_dispatcher.py
+++ b/tests/workers/test_rename_dispatcher.py
@@ -470,6 +470,7 @@ def test_mid_batch_failure_reports_accurate_results(tmp_path, monkeypatch):
 
 def test_staging_failure_rolls_back_directory(tmp_path, monkeypatch):
     """If staging fails, already-staged files return home and nothing commits."""
+    import workers.rename_dispatcher as rd
     from models.media_file import MediaFile
     from workers.rename_dispatcher import plan_rename
 
@@ -478,15 +479,17 @@ def test_staging_failure_rolls_back_directory(tmp_path, monkeypatch):
     content_b = Path(path_b).read_bytes()
 
     # In an a <-> b swap both files stage first; fail b.mp3's staging rename
-    # so the whole directory is rolled back before any commit runs.
-    real_link = os.link
+    # so the whole directory is rolled back before any commit runs. Patch
+    # _rename_no_clobber (the seam every staging/commit/restore rename uses)
+    # rather than os.link, which only the POSIX branch calls.
+    real_rename = rd._rename_no_clobber
 
-    def failing_link(src, dst, **kwargs):
+    def failing_rename(src, dst):
         if os.path.basename(src) == "b.mp3":
             raise OSError(5, "simulated I/O error")  # EIO
-        return real_link(src, dst, **kwargs)
+        return real_rename(src, dst)
 
-    monkeypatch.setattr(os, "link", failing_link)
+    monkeypatch.setattr(rd, "_rename_no_clobber", failing_rename)
 
     tasks = [
         plan_rename(MediaFile(path_a), "b", RENAME_COLLISION_AUTO_DISAMBIGUATE),
@@ -507,6 +510,7 @@ def test_staging_failure_rolls_back_directory(tmp_path, monkeypatch):
 
 def test_failed_commits_restore_staged_files(tmp_path, monkeypatch):
     """Staged files whose commits fail are moved back to their old names."""
+    import workers.rename_dispatcher as rd
     from models.media_file import MediaFile
     from workers.rename_dispatcher import _STAGING_NAME_PREFIX, plan_rename
 
@@ -517,17 +521,17 @@ def test_failed_commits_restore_staged_files(tmp_path, monkeypatch):
     # Swap where both commits fail (their sources are staging names); both
     # old names stay free, so both restores must succeed. A restore renames
     # ".yaamt-rename-x.mp3" back to "x.mp3"; only fail the other moves.
-    real_link = os.link
+    real_rename = rd._rename_no_clobber
 
-    def failing_link(src, dst, **kwargs):
+    def failing_rename(src, dst):
         src_name = os.path.basename(src)
         dst_name = os.path.basename(dst)
         is_restore = src_name == f"{_STAGING_NAME_PREFIX}{dst_name}"
         if src_name.startswith(_STAGING_NAME_PREFIX) and not is_restore:
             raise OSError(5, "simulated I/O error")  # EIO
-        return real_link(src, dst, **kwargs)
+        return real_rename(src, dst)
 
-    monkeypatch.setattr(os, "link", failing_link)
+    monkeypatch.setattr(rd, "_rename_no_clobber", failing_rename)
 
     tasks = [
         plan_rename(MediaFile(path_a), "b", RENAME_COLLISION_AUTO_DISAMBIGUATE),
@@ -544,6 +548,7 @@ def test_failed_commits_restore_staged_files(tmp_path, monkeypatch):
 
 def test_directory_failure_does_not_affect_other_directories(tmp_path, monkeypatch):
     """Chunks are independent: an aborted directory leaves others untouched."""
+    import workers.rename_dispatcher as rd
     from models.media_file import MediaFile
     from workers.rename_dispatcher import plan_rename
 
@@ -555,14 +560,14 @@ def test_directory_failure_does_not_affect_other_directories(tmp_path, monkeypat
     (path_c,) = _copy_fixtures(dir_two, ["c.mp3"])
 
     # Abort dir_one's swap at staging time; dir_two's rename must proceed.
-    real_link = os.link
+    real_rename = rd._rename_no_clobber
 
-    def failing_link(src, dst, **kwargs):
+    def failing_rename(src, dst):
         if os.path.basename(src) == "b.mp3":
             raise OSError(5, "simulated I/O error")  # EIO
-        return real_link(src, dst, **kwargs)
+        return real_rename(src, dst)
 
-    monkeypatch.setattr(os, "link", failing_link)
+    monkeypatch.setattr(rd, "_rename_no_clobber", failing_rename)
 
     tasks = [
         plan_rename(MediaFile(path_a), "b", RENAME_COLLISION_AUTO_DISAMBIGUATE),


### PR DESCRIPTION
## Summary
Implements a manual refresh feature (F5 / View > Refresh) that reloads both the directory tree and file list while preserving the user's file selection. Refactors directory pane initialization and loading logic to support this feature and improve code organization.

## Key Changes

- **Manual Refresh Feature**: Added `on_refresh_requested()` handler triggered by F5 key or toolbar/menu button that reloads the current directory while restoring the previously selected files
- **Directory Pane Refactoring**: 
  - Extracted `_install_dir_model()` to centralize QFileSystemModel setup and signal wiring
  - Extracted `_refresh_directory_pane()` to force filesystem re-read by replacing the model
  - Both methods properly handle signal blocking to prevent competing loads
- **Load Directory Refactoring**: Extracted `_load_directory()` method to consolidate file pane loading logic with optional selection restoration
- **Selection Restoration**: Added `_pending_selection_paths` field to track files to re-select after a manual refresh completes, ensuring stale workers don't restore outdated selections
- **Helper Methods**: Added `_get_selected_row_data()`, `_get_selected_file_paths()`, and `_get_selected_media_files()` to reduce code duplication across multiple features
- **Menu Improvements**: 
  - Renamed `setup_columns_in_view_menu()` to `_rebuild_column_menu()` for clarity
  - Moved View menu construction to `_create_menus()` to prevent wiping non-column actions during column resets
  - Added refresh action to View menu alongside toolbar button
- **Imports**: Added `QKeySequence` and `QSignalBlocker` imports to support new functionality

## Notable Implementation Details

- QFileSystemModel has no public API to re-read the filesystem, so manual refresh works by installing a fresh model instance
- Signal blocking is used strategically to prevent `setCurrentIndex()` calls from triggering competing loads during refresh and directory pane rebuilds
- Worker ID guards ensure stale workers from superseded operations never restore selections
- The View menu is now constructed once in `_create_menus()` rather than being cleared and rebuilt, preserving all actions including the new refresh action during column resets
- Comprehensive test suite validates refresh behavior, selection restoration, stale worker handling, and menu persistence

https://claude.ai/code/session_01EtTR487L1wWYqBkccLXyzX